### PR TITLE
Making a preview process work in an async fashion

### DIFF
--- a/actions/helper.go
+++ b/actions/helper.go
@@ -220,7 +220,7 @@ func StartWorker(w utils.PreviewWorker) {
 }
 
 
-
+// This might not need to be a fatal on an error, but is nice for debugging now
 func CreateMediaPreview(c *models.Container, mc *models.MediaContainer, fsize int64) (string, error) {
     cntPath := filepath.Join(appCfg.Dir, c.Name)
     dstPath := GetContainerPreviewDst(c)
@@ -229,6 +229,8 @@ func CreateMediaPreview(c *models.Container, mc *models.MediaContainer, fsize in
     if exist_err != nil {
         return "", exist_err
     }
+
+    // TODO: ensure that other content does not explode...
     dstFqPath, err := utils.GetImagePreview(cntPath, mc.Src, dstPath, fsize)
     if err != nil {
         log.Fatal(err)

--- a/grifts/db.go
+++ b/grifts/db.go
@@ -46,6 +46,10 @@ var _ = grift.Namespace("db", func() {
         }
         cfg := actions.GetCfg()
         cfg.Dir = dir_name
+        coreCount, cErr := strconv.Atoi(envy.Get("CORE_COUNT", strconv.Itoa(4)))
+        if cErr != nil {
+            cfg.CoreCount = coreCount
+        }
         fmt.Printf("Using size %d for preview creation", size)
         return actions.CreateAllPreviews(size)
 	})

--- a/grifts/db.go
+++ b/grifts/db.go
@@ -47,10 +47,12 @@ var _ = grift.Namespace("db", func() {
         cfg := actions.GetCfg()
         cfg.Dir = dir_name
         coreCount, cErr := strconv.Atoi(envy.Get("CORE_COUNT", strconv.Itoa(4)))
-        if cErr != nil {
+        if cErr == nil {
             cfg.CoreCount = coreCount
+        } else {
+            cfg.CoreCount = 4
         }
-        fmt.Printf("Using size %d for preview creation", size)
+        fmt.Printf("Using size %d for preview creation and starting with n cores %d", size, cfg.CoreCount)
         return actions.CreateAllPreviews(size)
 	})
     // Then add in linkage to the related models.

--- a/utils/content.go
+++ b/utils/content.go
@@ -34,6 +34,7 @@ type DirConfigEntry struct {
 	Limit           int    // The absolute max you can load in a single operation
 	Initialized     bool
     UseDatabase     bool
+    CoreCount       int
     StaticResourcePath string
 }
 
@@ -46,6 +47,7 @@ type DirConfigEntry struct {
 func InitConfig(dir_root string, cfg *DirConfigEntry) *DirConfigEntry {
 	cfg.Dir = dir_root  // Always Common
 	cfg.Initialized = true
+    cfg.CoreCount = 4
 	return cfg
 }
 

--- a/utils/previews.go
+++ b/utils/previews.go
@@ -8,16 +8,29 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+    "contented/models"
 	"github.com/nfnt/resize"
     "github.com/gofrs/uuid"
 )
 
 // Used in the case of async processing when creating Preview results
-type ProcessingResult struct {
+type PreviewResult struct {
     C_ID uuid.UUID
     MC_ID uuid.UUID
     Preview string
     Err error
+}
+
+type PreviewRequest struct {
+    C *models.Container
+    Mc *models.MediaContainer
+    Out chan PreviewResult
+    Size int64
+}
+
+type PreviewWorker struct {
+    Id int
+    In chan PreviewRequest
 }
 
 func MakePreviewPath(dstPath string) error {


### PR DESCRIPTION
Setup so that the core count can be configured (still need real performance tests)
Now when run from the buffalo task db:preview it will update the db with previews.