### PR TITLE
[Is-114] - Provide the ability to restrict what is loaded via .env files (filename or content type)

### DIFF
--- a/.env
+++ b/.env
@@ -9,10 +9,10 @@ CONTENT_DIR=""
 # The default location where the index.html is going to be placed (likely with js/css)
 STATIC_RESOURCE_PATH="./public/build"
 
-# Include only files by regex match on filename or content_type (comma seperated)
+# Include only files by regex match on filename or content_type
 INCLUDE_FILES_MATCH=".*"
-INCLUDE_TYPES_MATCH=".*"
+INCLUDE_TYPES_MATCH="image"
 
-# Exclude files by regex match on filename or content_type (comma seperated)
+# Exclude files by regex match on filename or content_type
 EXCLUDE_FILES_MATCH=""
 EXCLUDE_TYPES_MATCH=""

--- a/.env
+++ b/.env
@@ -10,7 +10,7 @@ CONTENT_DIR=""
 STATIC_RESOURCE_PATH="./public/build"
 
 # Include only files by regex match on filename or content_type
-INCLUDE_FILES_MATCH=".*"
+INCLUDE_FILES_MATCH=""
 INCLUDE_TYPES_MATCH="image"
 
 # Exclude files by regex match on filename or content_type

--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 LIMIT=5000
-PREVIEW=12
 
-USE_DATABASE="false"
+# true|false Should it try to use the database or just an in memory version
+USE_DATABASE="true"
 
 # You can specify this here or override with the env DIR.  ie export DIR="/fq/dir" && buffalo dev
 CONTENT_DIR=""
@@ -9,10 +9,19 @@ CONTENT_DIR=""
 # The default location where the index.html is going to be placed (likely with js/css)
 STATIC_RESOURCE_PATH="./public/build"
 
-# Include only files by regex match on filename or content_type
+# Include only files by regex match on filename or content_type/mime type
 INCLUDE_FILES_MATCH=""
 INCLUDE_TYPES_MATCH="image"
 
-# Exclude files by regex match on filename or content_type
+# Exclude files by regex match on filename or content_type/mime type
 EXCLUDE_FILES_MATCH=""
 EXCLUDE_TYPES_MATCH=""
+
+# How many files should load each time a load call is made under a preview #TODO: Use this
+PREVIEW=12
+
+# When running the buffalo task db:preview make a preview if the file is > this size
+CREATE_PREVIEW_SIZE=1024000
+
+# Core count is how many processors are going to be available (used when creating previews)
+CORE_COUNT=4

--- a/.env
+++ b/.env
@@ -8,3 +8,11 @@ CONTENT_DIR=""
 
 # The default location where the index.html is going to be placed (likely with js/css)
 STATIC_RESOURCE_PATH="./public/build"
+
+# Include only files by regex match on filename or content_type (comma seperated)
+INCLUDE_FILES_MATCH=".*"
+INCLUDE_TYPES_MATCH=".*"
+
+# Exclude files by regex match on filename or content_type (comma seperated)
+EXCLUDE_FILES_MATCH=""
+EXCLUDE_TYPES_MATCH=""

--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -47,7 +47,7 @@ func init_fake_app(use_db bool) *utils.DirConfigEntry {
 	dir, _ := envy.MustGet("DIR")
 	fmt.Printf("Using directory %s\n", dir)
 
-	cfg := GetCfg()
+	cfg := utils.GetCfg()
 	utils.InitConfig(dir, cfg)
     cfg.UseDatabase = use_db  // Set via .env or USE_DATABASE as an environment var
     cfg.StaticResourcePath = "./public/build"

--- a/actions/app.go
+++ b/actions/app.go
@@ -3,6 +3,7 @@ package actions
 import (
     "log"
     "contented/models"
+    "contented/utils"
     "net/http"
     "github.com/gobuffalo/buffalo"
     "github.com/gobuffalo/buffalo-pop/v2/pop/popmw"
@@ -75,7 +76,7 @@ func App(UseDatabase bool) *buffalo.App {
         app.GET("/ui/{path}/{idx}", AngularIndex)
 
         // Need to make the file serving location smarter (serve the dir + serve static?)
-        cfg := GetCfg()
+        cfg := utils.GetCfg()
         app.ServeFiles("/public/build", http.Dir(cfg.StaticResourcePath))
         app.ServeFiles("/public/css", http.Dir(cfg.StaticResourcePath))
 

--- a/actions/helper.go
+++ b/actions/helper.go
@@ -33,13 +33,15 @@ func CreateInitialStructure(dir_name string) error {
     if err != nil {
         return errors.WithStack(err)
     }
+    // This should be initialized
+    cfg := utils.GetCfg()
 
     // TODO: Need to do this in a single transaction vs partial
-    // TODO: Print vs log... might need to setup logging in the Grift I guess
     for _, dir := range dirs {
         log.Printf("Adding directory %s with id %s\n", dir.Name, dir.ID)
 
-        media := utils.FindMedia(dir, 90001, 0) // A more sensible limit?
+        // A more sensible limit on the absolute max lookup?
+        media := utils.FindMediaMatcher(dir, 90001, 0, cfg.IncFiles, cfg.ExcFiles) 
         log.Printf("Adding Media to %s with total media %d \n", dir.Name, len(media))
 
         // Use the database version of uuid generation (minimize the miniscule conflict)

--- a/actions/helper.go
+++ b/actions/helper.go
@@ -76,7 +76,8 @@ func ClearContainerPreviews(c *models.Container) error {
 
 // TODO: Move to utils or make it wrapped for some reason?
 func GetContainerPreviewDst(c *models.Container) string {
-    return filepath.Join(appCfg.Dir, c.Name, "container_previews")
+    cfg := utils.GetCfg()
+    return filepath.Join(cfg.Dir, c.Name, "container_previews")
 }
 
 func CreateAllPreviews(preview_above_size int64) error {
@@ -133,7 +134,7 @@ func CreateMediaPreviews(c *models.Container, media models.MediaContainers, fsiz
     if len(media) == 0 {
         return models.MediaContainers{}, nil 
     }
-    cfg := GetCfg()
+    cfg := utils.GetCfg()
     processors := cfg.CoreCount
     if processors <= 0 {
         processors = 1 // Without at least one processor this will hang forever
@@ -222,7 +223,8 @@ func StartWorker(w utils.PreviewWorker) {
 
 // This might not need to be a fatal on an error, but is nice for debugging now
 func CreateMediaPreview(c *models.Container, mc *models.MediaContainer, fsize int64) (string, error) {
-    cntPath := filepath.Join(appCfg.Dir, c.Name)
+    cfg := utils.GetCfg()
+    cntPath := filepath.Join(cfg.Dir, c.Name)
     dstPath := GetContainerPreviewDst(c)
 
     _, exist_err :=  utils.PreviewExists(mc.Src, dstPath)

--- a/actions/helper.go
+++ b/actions/helper.go
@@ -22,19 +22,20 @@ import (
 
 
 // Process all the directories and get a valid setup into the DB
-func CreateInitialStructure(dir_name string) error {
-    dirs := utils.FindContainers(dir_name)
+// Probably should return a count of everything
+func CreateInitialStructure(cfg *utils.DirConfigEntry) error {
+    dirs := utils.FindContainers(cfg.Dir)
     log.Printf("Found %d sub-directories.\n", len(dirs))
     if len(dirs) == 0 {
-        return errors.New("No subdirectories found under path: " + dir_name)
+        return errors.New("No subdirectories found under path: " + cfg.Dir)
     }
 
+    // Optional?  Some sort of crazy merge for later?
     err := models.DB.TruncateAll()
     if err != nil {
         return errors.WithStack(err)
     }
     // This should be initialized
-    cfg := utils.GetCfg()
 
     // TODO: Need to do this in a single transaction vs partial
     for _, dir := range dirs {

--- a/actions/helper_test.go
+++ b/actions/helper_test.go
@@ -19,8 +19,10 @@ import (
 
 func GetScreens() (*models.Container, models.MediaContainers) {
 	dir, _ := envy.MustGet("DIR")
-    appCfg.Dir = dir
-    appCfg.CoreCount = 3
+
+    cfg := utils.GetCfg()
+    cfg.Dir = dir
+    cfg.CoreCount = 3
     cnts := utils.FindContainers(dir)
 
     var screenCnt *models.Container = nil
@@ -71,7 +73,9 @@ func (as *ActionSuite) Test_InitialCreation() {
 
 func (as *ActionSuite) Test_ImgPreview() {
 	dir, _ := envy.MustGet("DIR")
-    appCfg.Dir = dir
+
+    cfg := utils.GetCfg()
+    cfg.Dir = dir
 
     id, _ := uuid.NewV4()
     cnt := models.Container{
@@ -172,7 +176,8 @@ func (as *ActionSuite) Test_PreviewAllData() {
 	dir, _ := envy.MustGet("DIR")
     as.NotEmpty(dir, "The test must specify a directory to run on")
 
-    appCfg.Dir = dir
+    cfg := utils.GetCfg()
+    cfg.Dir = dir
     c_err := CreateInitialStructure(dir)
     as.NoError(c_err, "Failed to build out the initial database")
 

--- a/actions/helper_test.go
+++ b/actions/helper_test.go
@@ -160,7 +160,7 @@ func (as *ActionSuite) TestAsyncContainerPreviews() {
     for _, p_mc := range previews {
         as.NotEqual(p_mc.Preview, "", "All results should have a preview")
     }
-    // TODO: Validate the previews are created
+    // TODO: Validate the previews are created on disk
     // Map the results back to the media containers
     // Maybe just return them vs update the DB
 }

--- a/actions/home.go
+++ b/actions/home.go
@@ -5,7 +5,7 @@ import (
     "path/filepath"
 	"io/ioutil"
 	"net/http"
-
+    "contented/utils"
 	"github.com/gobuffalo/buffalo"
 	"github.com/gobuffalo/buffalo/render"
 )
@@ -18,7 +18,7 @@ func HomeHandler(c buffalo.Context) error {
 
 // Replace this with nginx or something else better at serving static content (probably)
 func AngularIndex(c buffalo.Context) error {
-    cfg := GetCfg()
+    cfg := utils.GetCfg()
 	index := filepath.Join(cfg.StaticResourcePath, "index.html")
 
 	// TODO:  I guess this is dumb if I have to read the thing anyway...

--- a/actions/manager.go
+++ b/actions/manager.go
@@ -18,29 +18,9 @@ import (
     //"github.com/gobuffalo/pop/v5/defaults"
 )
 
-// HomeHandler is a default handler to serve up
-var DefaultLimit int = 10000 // The max limit set by environment variable
-var DefaultPreviewCount int = 8
-var DefaultUseDatabase bool = false
-
-// https://medium.com/@TobiasSchmidt89/the-singleton-object-oriented-design-pattern-in-golang-9f6ce75c21f7
-var appCfg utils.DirConfigEntry = utils.DirConfigEntry{
-    Initialized:  false,
-    UseDatabase: true,
-    Dir:          "",
-    PreviewCount: DefaultPreviewCount,
-    Limit:        DefaultLimit,
-}
-
-func GetCfg() *utils.DirConfigEntry {
-    return &appCfg
-}
-func SetCfg(cfg utils.DirConfigEntry) {
-    appCfg = cfg
-}
-
 func GetManager(c *buffalo.Context) ContentManager {
-    return CreateManager(&appCfg, c)
+    cfg := utils.GetCfg()
+    return CreateManager(cfg, c)
 }
 
 
@@ -172,7 +152,7 @@ func PopulateMemoryView(dir_root string) (models.ContainerMap, models.MediaMap) 
     files := models.MediaMap{}
 
     log.Printf("Searching in %s", dir_root)
-    cfg := GetCfg()
+    cfg := utils.GetCfg()
 
     cnts := utils.FindContainers(dir_root)
     for idx, c := range cnts {
@@ -492,7 +472,8 @@ func (cm ContentManagerDB) FindActualFile(mc *models.MediaContainer) (string, er
 
 // Given a container ID and the src of a file in there, get a path and check if it exists
 func GetFilePathInContainer(src string, dir_name string) (string, error) {
-    path := filepath.Join(appCfg.Dir, dir_name)
+    cfg := utils.GetCfg()
+    path := filepath.Join(cfg.Dir, dir_name)
     fq_path := filepath.Join(path, src)
     if _, os_err := os.Stat(fq_path); os_err != nil {
         return fq_path, os_err

--- a/actions/manager.go
+++ b/actions/manager.go
@@ -172,10 +172,11 @@ func PopulateMemoryView(dir_root string) (models.ContainerMap, models.MediaMap) 
     files := models.MediaMap{}
 
     log.Printf("Searching in %s", dir_root)
+    cfg := GetCfg()
 
     cnts := utils.FindContainers(dir_root)
     for idx, c := range cnts {
-        media := utils.FindMedia(c, 90001, 0)  // TODO: Config this
+        media := utils.FindMediaMatcher(c, 90001, 0, cfg.IncFiles, cfg.ExcFiles)  // TODO: Config this
         // c.Contents = media
         c.Total = len(media)
         c.Idx = idx

--- a/actions/manager_test.go
+++ b/actions/manager_test.go
@@ -74,7 +74,7 @@ func (as *ActionSuite) Test_ManagerMediaContainer() {
 
 func (as *ActionSuite) Test_AssignManager() {
     dir, _ := envy.MustGet("DIR")
-    cfg := GetCfg()
+    cfg := utils.GetCfg()
     cfg.UseDatabase = false
     utils.InitConfig(dir, cfg)
 
@@ -89,7 +89,7 @@ func (as *ActionSuite) Test_AssignManager() {
     as.NoError(err)
     as.Greater(len(*mcs), 0, "It should have valid files in the manager")
 
-    appCfg.UseDatabase = false
+    cfg.UseDatabase = false
     ctx := getContext(app)
     man := GetManager(&ctx)  // New Reference but should have the same count of media
     mcs_2, _ := man.ListAllMedia(1, 9000)

--- a/actions/web.go
+++ b/actions/web.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strings"
 	"github.com/gobuffalo/buffalo"
 	"github.com/gofrs/uuid"
 )
@@ -18,17 +17,11 @@ type HttpError struct {
 
 // Builds out information given the application and the content directory
 func SetupContented(app *buffalo.App, contentDir string, numToPreview int, limit int) {
-	if !strings.HasSuffix(contentDir, "/") {
-		contentDir = contentDir + "/"
-	}
-	log.Printf("Setting up the content directory with %s", contentDir)
+    cfg := utils.GetCfg()
 
-	utils.InitConfig(contentDir, &appCfg)
-	appCfg.PreviewCount = numToPreview
-	appCfg.Limit = limit
-
+    // TODO: Check DIR exists
 	// TODO: Somehow need to move the dir into App, but first we want to validate the dir...
-	app.ServeFiles("/static", http.Dir(appCfg.Dir))
+	app.ServeFiles("/static", http.Dir(cfg.Dir))
 }
 
 func FullHandler(c buffalo.Context) error {

--- a/actions/web.go
+++ b/actions/web.go
@@ -11,11 +11,6 @@ import (
 	"github.com/gofrs/uuid"
 )
 
-type PreviewResults struct {
-	Success bool                `json:"success"`
-	Results []utils.DirContents `json:"results"`
-}
-
 type HttpError struct {
 	Error string `json:"error"`
 	Debug string `json:"debug"`

--- a/grifts/db.go
+++ b/grifts/db.go
@@ -1,9 +1,8 @@
 package grifts
 
 import (
-    "strconv"
     "fmt"
-    "contented/models"
+//    "contented/models"
     "contented/actions"
     "contented/utils"
 	"github.com/markbates/grift/grift"
@@ -15,45 +14,26 @@ var _ = grift.Namespace("db", func() {
 
 	grift.Desc("seed", "Populate the DB with a set of directory content.")
 	grift.Add("seed", func(c *grift.Context) error {
-        err := models.DB.TruncateAll()
-        if err != nil {
-            return errors.WithStack(err)
-        }
+        cfg := utils.GetCfg()
+        utils.InitConfigEnvy(cfg)
 
-        // Grab the directory which we want to process
-        dir_name, d_err := envy.MustGet("DIR")
+        // Require the directory which we want to process (maybe just trust it is set)
+        _, d_err := envy.MustGet("DIR")
         if d_err != nil {
             return errors.WithStack(d_err)
         }
         // Clean out the current DB setup then builds a new one
-        return actions.CreateInitialStructure(dir_name)
+        fmt.Printf("Configuration is loaded %s Starting import", cfg)
+        return actions.CreateInitialStructure(cfg.Dir)
 	})
     // Then add the content for the entire directory structure
 
 	grift.Add("preview", func(c *grift.Context) error {
-        // TODO: Strip this out into a different function
-        var size int64 = 1024 * 1000 * 2
-        psize := envy.Get("PREVIEW_IF_GREATER", "")
-        if psize != "" {
-            setSize, i_err := strconv.ParseInt(psize, 10, 64)
-            if i_err == nil {
-                size = setSize
-            }
-        }
-        dir_name, d_err := envy.MustGet("DIR")
-        if d_err != nil {
-            return errors.WithStack(d_err)
-        }
         cfg := utils.GetCfg()
-        cfg.Dir = dir_name
-        coreCount, cErr := strconv.Atoi(envy.Get("CORE_COUNT", strconv.Itoa(4)))
-        if cErr == nil {
-            cfg.CoreCount = coreCount
-        } else {
-            cfg.CoreCount = 4
-        }
-        fmt.Printf("Using size %d for preview creation and starting with n cores %d", size, cfg.CoreCount)
-        return actions.CreateAllPreviews(size)
+        utils.InitConfigEnvy(cfg)
+        fmt.Printf("Configuration is loaded %s doing preview creation", cfg)
+
+        // TODO: This should use the managers probably (allow for memory manager previews)
+        return actions.CreateAllPreviews(cfg.PreviewOverSize)
 	})
-    // Then add in linkage to the related models.
 })

--- a/grifts/db.go
+++ b/grifts/db.go
@@ -5,7 +5,7 @@ import (
     "fmt"
     "contented/models"
     "contented/actions"
-    //"contented/utils"
+    "contented/utils"
 	"github.com/markbates/grift/grift"
     "github.com/pkg/errors"
     "github.com/gobuffalo/envy"
@@ -44,7 +44,7 @@ var _ = grift.Namespace("db", func() {
         if d_err != nil {
             return errors.WithStack(d_err)
         }
-        cfg := actions.GetCfg()
+        cfg := utils.GetCfg()
         cfg.Dir = dir_name
         coreCount, cErr := strconv.Atoi(envy.Get("CORE_COUNT", strconv.Itoa(4)))
         if cErr == nil {

--- a/grifts/db.go
+++ b/grifts/db.go
@@ -23,15 +23,15 @@ var _ = grift.Namespace("db", func() {
             return errors.WithStack(d_err)
         }
         // Clean out the current DB setup then builds a new one
-        fmt.Printf("Configuration is loaded %s Starting import", cfg)
-        return actions.CreateInitialStructure(cfg.Dir)
+        fmt.Printf("Configuration is loaded %s Starting import", cfg.Dir)
+        return actions.CreateInitialStructure(cfg)
 	})
     // Then add the content for the entire directory structure
 
 	grift.Add("preview", func(c *grift.Context) error {
         cfg := utils.GetCfg()
         utils.InitConfigEnvy(cfg)
-        fmt.Printf("Configuration is loaded %s doing preview creation", cfg)
+        fmt.Printf("Configuration is loaded %s doing preview creation", cfg.Dir)
 
         // TODO: This should use the managers probably (allow for memory manager previews)
         return actions.CreateAllPreviews(cfg.PreviewOverSize)

--- a/main.go
+++ b/main.go
@@ -16,6 +16,9 @@ func main() {
     appCfg := utils.GetCfg()
     utils.InitConfigEnvy(appCfg)
 	app := actions.App(appCfg.UseDatabase)
+
+    // TODO: Update or delete this method as it is not really doing anything
+    // Potentially just do the static hosting in the actions.App bit.
 	actions.SetupContented(app, "", 0, 0)
 	if err := app.Serve(); err != nil {
 		log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -2,10 +2,8 @@ package main
 
 import (
 	"contented/actions"
+	"contented/utils"
 	"log"
-	"os"
-	"strconv"
-	"github.com/gobuffalo/envy"
 )
 
 // main is the starting point for your Buffalo application.
@@ -15,41 +13,10 @@ import (
 // call `app.Serve()`, unless you don't want to start your
 // application that is. :)
 func main() {
-
-    // Should I move this into the config itself?
-    var err error
-	dir := envy.Get("DIR", "")
-    if dir == "" {
-        dir, err = envy.MustGet("CONTENT_DIR")  // From the .env file
-    }
-    staticDir := envy.Get("STATIC_RESOURCE_PATH", "./public/build")
-	limitCount, limErr := strconv.Atoi(envy.Get("LIMIT", strconv.Itoa(actions.DefaultLimit)))
-
-    // We need to get that actually get a default load somehow
-	previewCount, previewErr := strconv.Atoi(envy.Get("PREVIEW", strconv.Itoa(actions.DefaultPreviewCount)))
-    useDatabase, connErr := strconv.ParseBool(envy.Get("USE_DATABASE", strconv.FormatBool(actions.DefaultUseDatabase)))
-
-	if err != nil {
-		panic(err)
-	} else if limErr != nil {
-		panic(limErr)
-	} else if previewErr != nil {
-		panic(previewErr)
-	} else if _, noDirErr := os.Stat(dir); os.IsNotExist(noDirErr) {
-		panic(noDirErr)
-    } else if connErr != nil {
-        panic(connErr)
-    }
-
-    appCfg := actions.GetCfg()
-    appCfg.UseDatabase = useDatabase
-    appCfg.StaticResourcePath = staticDir
-
-	log.Printf("Parsed Env. Dir %s Limit %d with preview count %d\n", dir, limitCount, previewCount)
-    log.Printf("Use connection type of database %t\n", appCfg.UseDatabase)
-
+    appCfg := utils.GetCfg()
+    utils.InitConfigEnvy(appCfg)
 	app := actions.App(appCfg.UseDatabase)
-	actions.SetupContented(app, dir, previewCount, limitCount)
+	actions.SetupContented(app, "", 0, 0)
 	if err := app.Serve(); err != nil {
 		log.Fatal(err)
 	}

--- a/utils/content.go
+++ b/utils/content.go
@@ -94,8 +94,8 @@ func FindMedia(cnt models.Container, limit int, start_offset int) models.MediaCo
     return FindMediaMatcher(cnt, limit, start_offset, IncludeAllFiles, ExcludeNoFiles)
 }
 
-
-// Hate
+// func yup(string, string) bool is a required positive check on the filename and content type (default .*)
+// func nope(string, string) bool is a negative check (ie no zip files) default (everything is fine)
 func FindMediaMatcher(cnt models.Container, limit int, start_offset int, yup MediaMatcher, nope MediaMatcher) models.MediaContainers {
 	var arr = models.MediaContainers{}
     fqDirPath := filepath.Join(cnt.Path, cnt.Name)

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -41,6 +41,12 @@ func TestFindMedia(t *testing.T) {
     }
 }
 
+/*
+func Test_ContentTypeExclude(t *testing.T) {
+
+}
+*/
+
 func Test_ContentType(t *testing.T) {
 	imgName := "this_is_jp_eg"
 	dirPath := filepath.Join(testDir, "dir1")

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -41,7 +41,6 @@ func TestFindMedia(t *testing.T) {
     }
 }
 
-// hate
 func Test_MediaMatcher(t *testing.T) {
     containers := FindContainers(testDir)
 
@@ -49,12 +48,18 @@ func Test_MediaMatcher(t *testing.T) {
         return true // nothing should match
     }
 
+    // The positive include all cases handled by using FindMedia tests (default include all matches)
     for _, cnt := range containers {
         media := FindMediaMatcher(cnt, 0, 20, IncludeAllFiles, FailAll)
         if len(media) != 0 {
-            t.Errorf("None of these should possibly match")
+            t.Errorf("All Files should be excluded")
+        }
+        inc_test := FindMediaMatcher(cnt, 0, 20, FailAll, ExcludeNoFiles)
+        if len(inc_test) != 0 {
+            t.Errorf("None of these should be included")
         }
     }
+
 }
 
 func Test_ContentType(t *testing.T) {
@@ -117,6 +122,23 @@ func TestFindMediaOffset(t *testing.T) {
 
     if expect_dir == false {
         t.Fatal("The test directory dir3 was not found")
+    }
+}
+
+func Test_CreateMatcher(t *testing.T) {
+    matcher := CreateMatcher(".jpg|.png|.gif", "image")
+
+    valid_fn := "derp.jpg" 
+    valid_mime := "image/jpeg"
+    valid := matcher(valid_fn, valid_mime)
+    if !valid {
+        t.Errorf("The matcher should have been ok with fn %s and mime %s", valid_fn, valid_mime)
+    }
+
+    invalid_fn := "zugzug.zip"
+    invalid := matcher(invalid_fn, valid_mime)
+    if invalid {
+        t.Errorf("Does not match fn %s and mime %s", invalid_fn, valid_mime)
     }
 }
 

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -41,11 +41,21 @@ func TestFindMedia(t *testing.T) {
     }
 }
 
-/*
-func Test_ContentTypeExclude(t *testing.T) {
+// hate
+func Test_MediaMatcher(t *testing.T) {
+    containers := FindContainers(testDir)
 
+    FailAll := func(filename string, content_type string) bool {
+        return true // nothing should match
+    }
+
+    for _, cnt := range containers {
+        media := FindMediaMatcher(cnt, 0, 20, IncludeAllFiles, FailAll)
+        if len(media) != 0 {
+            t.Errorf("None of these should possibly match")
+        }
+    }
 }
-*/
 
 func Test_ContentType(t *testing.T) {
 	imgName := "this_is_jp_eg"

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -140,6 +140,13 @@ func Test_CreateMatcher(t *testing.T) {
     if invalid {
         t.Errorf("Does not match fn %s and mime %s", invalid_fn, valid_mime)
     }
+
+    wild_matcher := CreateMatcher("", ".*")
+    // empty_or_wild := matcher(empty_fn, wild_mime)
+    empty_or_wild := wild_matcher(invalid_fn, "application/x-bzip")
+    if !empty_or_wild {
+        t.Errorf("This should be a wildcard or empty match")
+    }
 }
 
 func example(sleep int, msg string, reply chan string) {


### PR DESCRIPTION
- It should import filter based on filename or content type
- It should be able to exclude via content type or filename

TODO:  
Ensure the creation logic uses the appCfg.IncFiles and appCfg.excFiles options
More tests
Ensure grift works
