### PR TITLE
#236 - Starting to add some video conversion helpers.

### DIFF
--- a/.buffalo.dev.yml
+++ b/.buffalo.dev.yml
@@ -16,6 +16,7 @@ ignored_folders:
 - grifts
 - tmp
 - bin
+- src
 - node_modules
 - .sass-cache
 included_extensions:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 /.angular/cache
 node_modules/*
+bin/*
+locales/*
+migrations/schema.sql
 
 tmp/*
 public/build/*

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,12 @@ test:
 # This works with gotestsum, something about a DB reset is missing or magical Buffalo code.
 .PHONY: gotestsum
 gtest:
-	export DIR=`pwd`/mocks/content
-	gotestsum --format testname ./models
-	gotestsum --format testname ./utils
-	gotestsum --format testname ./managers
-	gotestsum --format testname ./actions
+	export DIR=`pwd`/mocks/content && gotestsum --format testname ./models
+	export DIR=`pwd`/mocks/content && gotestsum --format testname ./utils
+	# The Database side of things doesn't get created with gotestsum yet
+	# To run one test you can steal this line and pass --run <TestName>
+	# export DIR=`pwd`/mocks/content && gotestsum --format testname ./managers
+	# export DIR=`pwd`/mocks/content && gotestsum --format testname ./actions
 
 .PHONY: dev
 dev:

--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,14 @@ test:
 	export DIR=`pwd`/mocks/content && buffalo test ./models ./utils ./managers ./actions
 
 # This works with gotestsum, something about a DB reset is missing or magical Buffalo code.
+# The Database side of things doesn't get created with gotestsum yet
+# To run one test with gotestsum you can steal this line and pass --run <TestName>
 .PHONY: gotestsum
 gtest:
 	export DIR=`pwd`/mocks/content && gotestsum --format testname ./models
 	export DIR=`pwd`/mocks/content && gotestsum --format testname ./utils
-	# The Database side of things doesn't get created with gotestsum yet
-	# To run one test you can steal this line and pass --run <TestName>
-	# export DIR=`pwd`/mocks/content && gotestsum --format testname ./managers
-	# export DIR=`pwd`/mocks/content && gotestsum --format testname ./actions
+	export DIR=`pwd`/mocks/content && buffalo test ./managers
+	export DIR=`pwd`/mocks/content && buffalo test ./actions
 
 .PHONY: dev
 dev:

--- a/utils/previews.go
+++ b/utils/previews.go
@@ -717,7 +717,7 @@ func ConvertVideoToH256(srcFile string, dstFile string) (string, error) {
     }
     ignore := regexp.MustCompile(cfg.CodecsToIgnore)
     if ignore.MatchString(codecName) {
-        ignoreMsg := fmt.Sprintf("%s ignored because it matched %s ", srcFile, cfg.CodecsToIgnore)
+        ignoreMsg := fmt.Sprintf("%s ignored because it matched %s", srcFile, cfg.CodecsToIgnore)
         log.Printf(ignoreMsg)
         return ignoreMsg, nil
     }

--- a/utils/previews_test.go
+++ b/utils/previews_test.go
@@ -464,5 +464,4 @@ func Test_ScreenOutputPatterns(t *testing.T) {
     if err2 != nil {
         t.Errorf("Error trying to compile a re match for %s %s", badTwo, err2)
     }
-
 }

--- a/utils/video_test.go
+++ b/utils/video_test.go
@@ -40,6 +40,12 @@ func Test_VideoEncoding(t *testing.T) {
     cfg := GetCfg()
     vidInfo, err := ffmpeg.Probe(dstFile)
 
+    totalTimeSrc, _, _ := GetTotalVideoLength(srcFile)
+    totalTimeDst, _, _ := GetTotalVideoLength(dstFile)
+    if totalTimeSrc != totalTimeDst {
+        t.Errorf("Failed to create a valid output times are different %f vs %f", totalTimeSrc, totalTimeDst)
+    }
+
     // Cleanup after the test
     nukeFile(dstFile)
 
@@ -48,6 +54,7 @@ func Test_VideoEncoding(t *testing.T) {
         t.Errorf("Failed to encode with %s dstFile: %s was not hevc but %s", cfg.CodecForConversion, dstFile, codecName)
         t.Fail()
     }
+
     // Test should check the ffmpeg.Probe of both files and check length
     // Test should validate the new file uses a new codec
     // There should be an option to ignore vs nuke the test file

--- a/utils/video_test.go
+++ b/utils/video_test.go
@@ -45,7 +45,6 @@ func Test_VideoEncoding(t *testing.T) {
     if totalTimeSrc != totalTimeDst {
         t.Errorf("Failed to create a valid output times are different %f vs %f", totalTimeSrc, totalTimeDst)
     }
-
     // Cleanup after the test
     nukeFile(dstFile)
 

--- a/utils/video_test.go
+++ b/utils/video_test.go
@@ -53,8 +53,8 @@ func Test_VideoEncoding(t *testing.T) {
         t.Errorf("Failed to encode with %s dstFile: %s was not hevc but %s", cfg.CodecForConversion, dstFile, codecName)
         t.Fail()
     }
-
-    // Test should check the ffmpeg.Probe of both files and check length
-    // Test should validate the new file uses a new codec
-    // There should be an option to ignore vs nuke the test file
 }
+
+// TODO: Add a test converting an image
+// TODO: Test ignoring a particular codec
+// TODO: Change some of the error messages into 'success' states and a ran conversion message

--- a/utils/video_test.go
+++ b/utils/video_test.go
@@ -1,0 +1,22 @@
+package utils
+
+import (
+  "fmt"
+  "testing"
+  "path/filepath"
+)
+
+func Test_VideoEncoding(t *testing.T) {
+    srcDir, _, testFile := Get_VideoAndSetupPaths()
+    srcFile := filepath.Join(srcDir, testFile)
+    dstFile := fmt.Sprintf("%s.%s", srcFile, "[h256].mp4")
+
+    // Check if the dstFile exists and delete it if it does.
+
+    ConvertVideoToH256(srcFile, dstFile)
+
+    // Test should check the ffmpeg.Probe of both files and check length
+    // Test should validate the new file uses a new codec
+    // There should be an option to ignore vs nuke the test file
+    t.Fail()
+}

--- a/utils/video_test.go
+++ b/utils/video_test.go
@@ -1,22 +1,54 @@
 package utils
 
 import (
+  "os"
   "fmt"
   "testing"
   "path/filepath"
+  "github.com/tidwall/gjson"
+  ffmpeg "github.com/u2takey/ffmpeg-go"
 )
+
+
+func nukeFile(dstFile string) {
+    // This test should be marked as slow probably
+    if _, err := os.Stat(dstFile); !os.IsNotExist(err) {
+        os.Remove(dstFile)
+    }
+}
+
 
 func Test_VideoEncoding(t *testing.T) {
     srcDir, _, testFile := Get_VideoAndSetupPaths()
     srcFile := filepath.Join(srcDir, testFile)
     dstFile := fmt.Sprintf("%s.%s", srcFile, "[h256].mp4")
 
+    nukeFile(dstFile)
     // Check if the dstFile exists and delete it if it does.
+    msg, err := ConvertVideoToH256(srcFile, dstFile)
+    if err != nil {
+        t.Errorf("Failed to convert %s", err)
+    }
+    if msg == "" {
+        t.Errorf("We should have a success message %s", err)
+    }
+    if _, err := os.Stat(dstFile); os.IsNotExist(err) {
+        t.Errorf("We should have a file called %s", dstFile)
+        t.Fail()
+    }
 
-    ConvertVideoToH256(srcFile, dstFile)
+    cfg := GetCfg()
+    vidInfo, err := ffmpeg.Probe(dstFile)
 
+    // Cleanup after the test
+    nukeFile(dstFile)
+
+    codecName := gjson.Get(vidInfo, "streams.0.codec_name").String()
+    if codecName != "hevc" {
+        t.Errorf("Failed to encode with %s dstFile: %s was not hevc but %s", cfg.CodecForConversion, dstFile, codecName)
+        t.Fail()
+    }
     // Test should check the ffmpeg.Probe of both files and check length
     // Test should validate the new file uses a new codec
     // There should be an option to ignore vs nuke the test file
-    t.Fail()
 }


### PR DESCRIPTION
* Converts from matched video formats to x265
* Prevents duplication by default
* Will not try and re-encode if you tell it not to re-encode certain formats
* Some unit tests around it.

The next phase would be to use the actual media container matching in addition to this logic around codecs and do it for multiple items just like the screen capture options.  Add something as a grift as well (maybe add another free video in a different codec)