### PR TITLE
#310 - Making it so the video encoder will check the destination is a valid video at the correct duration.

### DIFF
--- a/actions/contents.go
+++ b/actions/contents.go
@@ -143,7 +143,7 @@ func (v ContentsResource) Destroy(c buffalo.Context) error {
 		return err
 	}
 
-	// TODO: Manager should probably be the thing doing updates etc.
+	// TODO: Manager should ABSOLUTELY be the thing doing updates etc.
 	// Allocate an empty Content
 	contentContainer := &models.Content{}
 

--- a/managers/encoding.go
+++ b/managers/encoding.go
@@ -1,166 +1,173 @@
 package managers
 
 import (
-  "fmt"
-  "log"
-//  "strings"
-  "contented/models"
-  "contented/utils"
-  //"github.com/gobuffalo/nulls"
-  //"github.com/gofrs/uuid"
-  "github.com/pkg/errors" 
+	"fmt"
+	"log"
+
+	//  "strings"
+	"contented/models"
+	"contented/utils"
+
+	//"github.com/gobuffalo/nulls"
+	//"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
 )
 
 // Init a manager and pass it in or just do this via config value instead of a pass in
 func EncodeVideos(cm ContentManager) error {
-    cnts, c_err := cm.ListContainers(0, 9001) // Might need to make this smarter (obviously)
-    if c_err != nil {
-        return c_err
-    }
-    if len(*cnts) == 0 {
-        return errors.New("No Containers were found in the database")
-    }
+	cnts, c_err := cm.ListContainers(0, 9001) // Might need to make this smarter (obviously)
+	if c_err != nil {
+		return c_err
+	}
+	if len(*cnts) == 0 {
+		return errors.New("No Containers were found in the database")
+	}
 
-    all_results := utils.EncodingResults{}
-    for _, cnt := range *cnts {
-        results, err := EncodeContainer(&cnt, cm)
-        if (err == nil && results != nil && len(*results) > 0) {
-            all_results = append(all_results, *results...)
-        }
-    }
+	all_results := utils.EncodingResults{}
+	for _, cnt := range *cnts {
+		results, err := EncodeContainer(&cnt, cm)
+		if err == nil && results != nil && len(*results) > 0 {
+			all_results = append(all_results, *results...)
+		}
+	}
 
-    if len(all_results) == 0 {
-        log.Printf("Found nothing that should be encoded (or everything is already encoded)")
-        return nil
-    }
+	if len(all_results) == 0 {
+		log.Printf("Found nothing that should be encoded (or everything is already encoded)")
+		return nil
+	}
 
-    lineBreak := "===================================================="
-    log.Printf("Encoding complete\n%s\n", lineBreak)
-    for _, res := range all_results {
-        if res.Err == nil {
-            // Again, original mc lookup?
-            msg := fmt.Sprintf("Successfully encoded %s media ID %s", res.NewVideo, res.MC_ID.String())
-            log.Print(msg)
-        }
-    }
-    log.Printf("Failures\n%s\n", lineBreak)
-    err_cnt := 0
-    for _, res := range all_results {
-        if res.Err != nil {
-            // Might want get the full link to the original video but it should be in the error
-            msg := fmt.Sprintf("Failure encoding %s failure was %s", res.Err, res.MC_ID.String())
-            log.Print(msg)
-            err_cnt++
-        }
-    }
-    if err_cnt > 0 {
-        return errors.New(fmt.Sprintf("Encoding had errors count(%d)", err_cnt))
-    }
-    return nil
+	lineBreak := "===================================================="
+	log.Printf("Encoding complete\n%s\n", lineBreak)
+	for _, res := range all_results {
+		if res.Err == nil {
+			msg := fmt.Sprintf("Encoding Success %s media ID %s\n", res.NewVideo, res.MC_ID.String())
+			log.Print(msg)
+		}
+	}
+	log.Printf(lineBreak)
+	log.Printf("Failures after this line %s", lineBreak)
+	err_cnt := 0
+	for _, res := range all_results {
+		if res.Err != nil {
+			// Might want get the full link to the original video but it should be in the error
+			msg := fmt.Sprintf("Failure encoding %s failure was %s", res.Err, res.MC_ID.String())
+			log.Print(msg)
+			err_cnt++
+		}
+	}
+	if err_cnt > 0 {
+		return errors.New(fmt.Sprintf("Encoding had errors count(%d)", err_cnt))
+	}
+	return nil
 }
 
-func EncodeContainer(c* models.Container, cm ContentManager) (*utils.EncodingResults, error) {
-    content, q_err := cm.ListContent(c.ID, 0, 90000)
-    if q_err != nil {
-      log.Fatal(q_err) // Also fatal if we can no longer list content (empty is just [])
-    }
+func EncodeContainer(c *models.Container, cm ContentManager) (*utils.EncodingResults, error) {
+	content, q_err := cm.ListContent(c.ID, 0, 90000)
+	if q_err != nil {
+		log.Fatal(q_err) // Also fatal if we can no longer list content (empty is just [])
+	}
 
-    // Remember that references in a range loop CHANGE the pointer on each loop so you MUST
-    // re-assign a variable if you want to build a new object with pointers.
-    toEncode := utils.EncodingRequests{}
-    for _, mc := range *content {
-        srcFile, _ := utils.GetFilePathInContainer(mc.Src, c.GetFqPath())
+	// Remember that references in a range loop CHANGE the pointer on each loop so you MUST
+	// re-assign a variable if you want to build a new object with pointers.
+	toEncode := utils.EncodingRequests{}
+	for _, mc := range *content {
+		srcFile, _ := utils.GetFilePathInContainer(mc.Src, c.GetFqPath())
 
-        // DstFile should split off the final extension \.xyz and replace it
-        dstFile := utils.GetVideoConversionName(srcFile)
-        msg, err, encode := utils.ShouldEncodeVideo(srcFile, dstFile)
+		// DstFile should split off the final extension \.xyz and replace it
+		dstFile := utils.GetVideoConversionName(srcFile)
+		msg, err, encode := utils.ShouldEncodeVideo(srcFile, dstFile)
 
-        if encode {
-            log.Printf("Will attempt to convert %s", msg)
-            ref_mc := mc  // Ensure the pointers don't get messed up
-            req := utils.EncodingRequest{C: c, Mc: &ref_mc, DstFile: dstFile, SrcFile: srcFile}
-            toEncode = append(toEncode, req)
-        } else if err != nil {
-            log.Printf("Error attempting to determine encoding err: %s msg: %s", err, msg)
-        } else {
-            // log.Printf("Ignoring this file msg: %s", msg)
-        }
-    }
-    if len(toEncode) > 0 {
-        return EncodeContainerContent(&toEncode, cm)
-    }
-    log.Printf("Did not find anything to encode under %s", c.Name)
-    return nil, nil
+		if encode {
+			log.Printf("Will attempt to convert %s", msg)
+			ref_mc := mc // Ensure the pointers don't get messed up
+			req := utils.EncodingRequest{C: c, Mc: &ref_mc, DstFile: dstFile, SrcFile: srcFile}
+			toEncode = append(toEncode, req)
+		} else if err != nil {
+			log.Printf("Error attempting to determine encoding err: %s msg: %s", err, msg)
+		} else {
+			// log.Printf("Ignoring this file msg: %s", msg)
+		}
+	}
+	if len(toEncode) > 0 {
+		return EncodeContainerContent(&toEncode, cm)
+	}
+	log.Printf("Did not find anything to encode under %s", c.Name)
+	return nil, nil
 }
 
 // Do encoding in parallel but many fewer processors.  It will be an interesting mix of
 // disk write and CPU use vs single process and heavy disk use.  Plus encoding video takes
 // some pretty serious memory use.
 func EncodeContainerContent(toEncode *utils.EncodingRequests, cm ContentManager) (*utils.EncodingResults, error) {
-    expected := len(*toEncode)
-    log.Printf("Attempting to encode N(%d) video files", expected)
-    cfg := utils.GetCfg()
-    processors := cfg.CoreCount / 2 // TODO: Another config... SO MANY
-    if processors <= 0 {
-        processors = 1 // Without at least one processor this will hang forever
-    }
+	expected := len(*toEncode)
+	log.Printf("Attempting to encode N(%d) video files", expected)
+	cfg := utils.GetCfg()
+	processors := cfg.CoreCount / 2 // TODO: Another config... SO MANY
+	if processors <= 0 {
+		processors = 1 // Without at least one processor this will hang forever
+	}
+	log.Printf("Starting %d processors for video encoding", processors)
 
-    reply := make(chan utils.EncodingResult, expected)
-    input := make(chan utils.EncodingRequest, expected)
-    // Starts the workers
-    for i := 0; i < processors; i++ {
-        pw := utils.EncodingWorker{Id: i, In: input}
-        go StartEncoder(pw)
-    }
+	reply := make(chan utils.EncodingResult, expected)
+	input := make(chan utils.EncodingRequest, expected)
+	// Starts the workers
+	for i := 0; i < processors; i++ {
+		pw := utils.EncodingWorker{Id: i, In: input}
+		go StartEncoder(pw)
+	}
 
-    for _, req := range *toEncode {
-        req.Out = reply
-        input <- req
-    }
+	for _, req := range *toEncode {
+		req.Out = reply
+		input <- req
+	}
 
-    total := 0
-    results := utils.EncodingResults{}
-    for res := range reply {
-        total++
-        if total == expected {
-            close(input)
-            close(reply)
-        }
-        r_cp := res
-        results = append(results, r_cp)
-    }
-    // We don't really have an error case here.
-    return &results, nil
+	total := 0
+	results := utils.EncodingResults{}
+	for res := range reply {
+		total++
+		if total == expected {
+			close(input)
+			close(reply)
+		}
+		r_cp := res
+		results = append(results, r_cp)
+	}
+	// We don't really have an error case here.
+	return &results, nil
 }
 
 func StartEncoder(ew utils.EncodingWorker) {
-    for req := range ew.In {
-        c := req.C
-        mc := req.Mc
+	for req := range ew.In {
+		c := req.C
+		mc := req.Mc
 
-        // Should check the on disk size and add a check to look at a post encode filesize
-        log.Printf("Worker %d Doing encoding for %s - %s\n", ew.Id, mc.ID.String(), mc.Src)
+		// Should check the on disk size and add a check to look at a post encode filesize
+		log.Printf("Worker %d Doing encoding for %s - %s\n", ew.Id, mc.ID.String(), mc.Src)
 
-        msg, err, converted := utils.ConvertVideoToH256(req.SrcFile, req.DstFile)
+		msg, err, converted := utils.ConvertVideoToH256(req.SrcFile, req.DstFile)
 
-        if err == nil && converted == false {
-            err = errors.New(fmt.Sprintf("A request was made to convert %s but it did not encode %s", req.SrcFile, msg))
-        }
+		if err == nil && converted == false {
+			err = errors.New(fmt.Sprintf("A request was made to convert %s but it did not encode %s", req.SrcFile, msg))
+		}
 
-        // Check that the destination is ACTUALLY a valid file
-        encodedSize := int64(0)
-        if err == nil {
-            _, encodedSize, err = utils.IsValidVideo(req.DstFile)
-        }
+		// TODO: Validate that the target file can be probed AND that it can be read and has the same
+		// playtime before determining if it is ok.
 
-        log.Printf("Size of the media %d and encoded %d", mc.SizeBytes, encodedSize)
-        req.Out <- utils.EncodingResult{
-            C_ID:    c.ID,
-            MC_ID:   mc.ID,
-            NewVideo: req.DstFile,
-            InitialSize: mc.SizeBytes,
-            EncodedSize: encodedSize,
-            Err: err,
-        }
-    }
+		// Check that the destination is ACTUALLY a valid file
+		encodedSize := int64(0)
+		if err == nil {
+			_, encodedSize, err, _ = utils.IsValidVideo(req.DstFile)
+			// TODO: Consider checking codec and duration here as well.
+		}
+
+		log.Printf("Size of the media %d and encoded %d", mc.SizeBytes, encodedSize)
+		req.Out <- utils.EncodingResult{
+			C_ID:        c.ID,
+			MC_ID:       mc.ID,
+			NewVideo:    req.DstFile,
+			InitialSize: mc.SizeBytes,
+			EncodedSize: encodedSize,
+			Err:         err,
+		}
+	}
 }

--- a/src/contented/content_view.spec.ts
+++ b/src/contented/content_view.spec.ts
@@ -107,7 +107,7 @@ describe('TestingContentViewCmp', () => {
         fixture.detectChanges();
         expect($(".loading").length).toEqual(1, "Loading UI should be present");
 
-        let url = `${ApiDef.contented.contentAll}/${fakeID}`;
+        let url = ApiDef.contented.content.replace("{id}", fakeID);
         let req = httpMock.expectOne(url);
         req.flush(donutMock);
         fixture.detectChanges();

--- a/src/contented/editor_content.spec.ts
+++ b/src/contented/editor_content.spec.ts
@@ -56,11 +56,13 @@ describe('EditorContentCmp', () => {
     fixture.detectChanges();
     expect($(".vscode-editor-cmp").length).withContext("There should be an editor").toEqual(1);
     tick(1000);
-    tick(1000);
 
     let url = ApiDef.contented.contentScreens.replace("{mcID}", cmp.content.id);
     httpMock.expectOne(url).flush(MockData.getScreens());
     fixture.detectChanges();
+    tick(1000);
+    fixture.detectChanges();
+    tick(1000);
   }));
 });
 

--- a/src/contented/splash.spec.ts
+++ b/src/contented/splash.spec.ts
@@ -66,8 +66,15 @@ describe('TestingSplashCmp', () => {
     it('Fully handles routing arguments', fakeAsync(() => {
         // Loads content (splash call)
         fixture.detectChanges();
-        tick(1000);
-        httpMock.expectOne(ApiDef.contented.splash).flush(MockData.splash());
+        tick(10000);
+
+        let splash = MockData.splash();
+        let expectVideoID = "fa5b3be0-7209-4461-8315-17a04c64f5b4";
+        httpMock.expectOne(ApiDef.contented.splash).flush(splash);
+        fixture.detectChanges();
+        tick(10000);
+        let url = ApiDef.contented.contentScreens.replace("{mcID}", expectVideoID);
+        httpMock.expectOne(url).flush(MockData.getScreens());
     }));
 });
 

--- a/src/contented/vscode_editor.cmp.ts
+++ b/src/contented/vscode_editor.cmp.ts
@@ -65,12 +65,12 @@ export class VSCodeEditorCmp implements OnInit {
   // The onInit from monaco pulls us OUT of a proper digest detection, so if I set initialized
   // directly in the 'afterMonacoInit' it is not detected till an edit.  This gets us insight into
   // if the monacoEditor is present and fixes any digest loop redraw errors...
-  monacoDigestHackery() {
+  monacoDigestHackery(count: number = 0) {
     _.delay(() => {
-      if (this.monacoEditor) {
-        this.initialized = true;
+      if (this.monacoEditor || count > 4) {
+        this.initialized = true;  // Eventually we want to give up.. probably the editor bailed.
       } else {
-        this.monacoDigestHackery();
+        this.monacoDigestHackery(count + 1);
       }
     }, 500);
   }
@@ -97,7 +97,7 @@ export class VSCodeEditorCmp implements OnInit {
     if (this.editor) {
       this.changeEmitter.pipe(
         distinctUntilChanged(),
-        debounceTime(50)
+        debounceTime(10)
       ).subscribe(
         (val: string) => {
             this.editForm.get("description").setValue(val);
@@ -109,7 +109,6 @@ export class VSCodeEditorCmp implements OnInit {
       });
     }
     this.afterMonaco();
-    //this.setReadOnly(this.readOnly);
   }
 
   public getTokens(tokenType: string = "keyword", language = this.language) {

--- a/utils/encoder.go
+++ b/utils/encoder.go
@@ -4,164 +4,188 @@ package utils
  * These functions deal with using ffmpeg to encode video to new formats (h265)
  */
 import (
-    "errors"
-    "log"
-    "os"
-    "regexp"
-    "strings"
-    "fmt"
-    "path/filepath"
-    "github.com/tidwall/gjson"
-    "github.com/gofrs/uuid"
-    ffmpeg "github.com/u2takey/ffmpeg-go"
-    "contented/models"
+	"contented/models"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/gofrs/uuid"
+	"github.com/tidwall/gjson"
+	ffmpeg "github.com/u2takey/ffmpeg-go"
 )
 
 // Used in the case of async processing when encoding.
 // Pretty much identical to previews but I might have to tweak this a lot
 type EncodingResult struct {
-    C_ID    uuid.UUID
-    MC_ID   uuid.UUID
-    NewVideo string
-    Err     error
+	C_ID     uuid.UUID
+	MC_ID    uuid.UUID
+	NewVideo string
+	Err      error
 
-    // We should ensure that there are some stats gathered around this.
-    InitialSize int64
-    EncodedSize int64
+	// We should ensure that there are some stats gathered around this.
+	InitialSize int64
+	EncodedSize int64
 }
 
 type EncodingRequest struct {
-    C    *models.Container
-    Mc   *models.Content
-    SrcFile string
-    DstFile string
-    Out  chan EncodingResult
+	C       *models.Container
+	Mc      *models.Content
+	SrcFile string
+	DstFile string
+	Out     chan EncodingResult
 }
 
 type EncodingWorker struct {
-    Id int
-    In chan EncodingRequest
+	Id int
+	In chan EncodingRequest
 }
 type EncodingRequests []EncodingRequest
 type EncodingResults []EncodingResult
 
-
 // Returns a message about the video codec, size of it, or if it is invalid.
-func IsValidVideo(srcFile string) (string, int64, error) {
-    srcStat, statErr := os.Stat(srcFile)
-    fileSize := int64(0)
-    codecName := ""
-    if statErr != nil {
-        return codecName, fileSize, statErr
-    }
-    fileSize = int64(srcStat.Size())
-    if fileSize == 0 {
-        return codecName, fileSize, errors.New(fmt.Sprintf("%s was empty or small %d", srcFile, fileSize))
-    }
+func IsValidVideo(srcFile string) (string, int64, error, string) {
+	srcStat, statErr := os.Stat(srcFile)
+	fileSize := int64(0)
+	codecName := ""
+	if statErr != nil {
+		return codecName, fileSize, statErr, ""
+	}
+	fileSize = int64(srcStat.Size())
+	if fileSize == 0 {
+		return codecName, fileSize, errors.New(fmt.Sprintf("%s was empty or small %d", srcFile, fileSize)), ""
+	}
 
-    filename := filepath.Base(srcFile)
-    path := filepath.Dir(srcFile)
-    contentType, tErr := GetMimeType(path, filename)
-    if tErr != nil {
-        return codecName, fileSize, tErr
-    }
-    if !strings.Contains(contentType, "video") {
-        msg := fmt.Sprintf("Not a video file so not converting %s", contentType)
-        return codecName, fileSize, errors.New(msg)
-    }
+	filename := filepath.Base(srcFile)
+	path := filepath.Dir(srcFile)
+	contentType, tErr := GetMimeType(path, filename)
+	if tErr != nil {
+		return codecName, fileSize, tErr, ""
+	}
+	if !strings.Contains(contentType, "video") {
+		msg := fmt.Sprintf("Not a video file so not converting %s", contentType)
+		return codecName, fileSize, errors.New(msg), ""
+	}
 
-    vidInfo, probeErr := GetVideoInfo(srcFile)
-    if probeErr != nil {
-        log.Printf("Couldn't probe %s", srcFile)
-        return codecName, fileSize, probeErr
-    }
-    codecName = gjson.Get(vidInfo, "streams.0.codec_name").String()
-    return codecName, fileSize, nil
+	vidInfo, probeErr := GetVideoInfo(srcFile)
+	if probeErr != nil {
+		log.Printf("Couldn't probe %s", srcFile)
+		return codecName, fileSize, probeErr, ""
+	}
+	codecName = gjson.Get(vidInfo, "streams.0.codec_name").String()
+	return codecName, fileSize, nil, vidInfo
 }
-
 
 // Expand this into something that can trim down the video info to the little bits we care about
 func GetVideoInfo(srcFile string) (string, error) {
-    return ffmpeg.Probe(srcFile)
+	return ffmpeg.Probe(srcFile)
 }
 
 /**
  *  This returns a message about what is happening with the encoding (should it do it etc).
  */
 func ShouldEncodeVideo(srcFile string, dstFile string) (string, error, bool) {
-    codecName, _, videoInvalid := IsValidVideo(srcFile)
-    if videoInvalid != nil {
-        return fmt.Sprintf("Not valid video %s", videoInvalid), nil, false
-    }
-    _, statErr := os.Stat(dstFile)
-    if !os.IsNotExist(statErr) {
-        existsMsg := fmt.Sprintf("Destination file already exists %s", dstFile)
-        return "", errors.New(existsMsg), false
-    }
-    // TODO: Config setting where if the filesize is too small we should _NOT_ reencode
+	codecName, _, videoInvalid, srcInfo := IsValidVideo(srcFile)
+	if videoInvalid != nil {
+		return fmt.Sprintf("Not valid video %s", videoInvalid), nil, false
+	}
 
-    // Check that the converted file doesn't exist
-    cfg := GetCfg()
-    log.Printf("The vidinfo codec %s converting to %s", codecName, cfg.CodecForConversion)
+	// Check that the converted file doesn't exist
+	cfg := GetCfg()
+	log.Printf("The current src codec %s checking if we should convert to %s", codecName, cfg.CodecForConversion)
 
-    // The CodecForConversion is NOT the name of the thing you convert to...
-    if cfg.CodecForConversion == codecName {
-        okMsg := fmt.Sprintf("%s Already in the desired codec %s", srcFile, cfg.CodecForConversion)
-        return okMsg, nil, false
-    }
+	// The CodecForConversion is NOT the name of the thing you convert to...
+	if cfg.CodecForConversion == codecName {
+		okMsg := fmt.Sprintf("%s Already in the desired codec %s", srcFile, cfg.CodecForConversion)
+		return okMsg, nil, false
+	}
 
-    matcher := regexp.MustCompile(cfg.CodecsToConvert)
-    if !matcher.MatchString(codecName) {
-        ignoreMsg := fmt.Sprintf("%s Not on the conversion list %s", srcFile, cfg.CodecsToConvert)
-        return ignoreMsg, nil, false
-    }
-    ignore := regexp.MustCompile(cfg.CodecsToIgnore)
-    if ignore.MatchString(codecName) {
-        ignoreMsg := fmt.Sprintf("%s ignored because it matched %s", srcFile, cfg.CodecsToIgnore)
-        return ignoreMsg, nil, false
-    }
+	// TODO: Config setting where if the filesize is too small we should _NOT_ reencode
+	matcher := regexp.MustCompile(cfg.CodecsToConvert)
+	if !matcher.MatchString(codecName) {
+		ignoreMsg := fmt.Sprintf("%s Not on the conversion list %s", srcFile, cfg.CodecsToConvert)
+		return ignoreMsg, nil, false
+	}
+	ignore := regexp.MustCompile(cfg.CodecsToIgnore)
+	if ignore.MatchString(codecName) {
+		ignoreMsg := fmt.Sprintf("%s ignored because it matched %s", srcFile, cfg.CodecsToIgnore)
+		return ignoreMsg, nil, false
+	}
 
-    msg := fmt.Sprintf("File will be converted from %s to %s\nOld File: %s\nNew File: %s", codecName, cfg.CodecForConversion, srcFile, dstFile)
-    return msg, nil, true
+	// This is where I need to fix the probe check. // hate
+	_, statErr := os.Stat(dstFile)
+	if !os.IsNotExist(statErr) {
+		dstInfo, err := GetVideoInfo(dstFile)
+		if err != nil {
+			// This should fail a test (might need to dump junk in the file)
+			msg := fmt.Sprintf("File %s exists but cannot probe dst video info (likely corrupt so re-encode) err: %s", dstFile, err)
+			log.Printf(msg)
+			return msg, nil, true
+		} else {
+			// Check the times (the name maybe the same but the content might differ if the time is off then re-encode)
+			existsMsg := fmt.Sprintf("Destination file already exists %s checking if it is valid", dstFile)
+			log.Print(existsMsg)
+
+			srcDuration := gjson.Get(srcInfo, "format.duration").Float()
+			dstDuration := gjson.Get(dstInfo, "format.duration").Float()
+
+			// TODO: could also check we are in the actually requested codec as well.
+			if srcDuration == dstDuration { // Within minimal amount length?
+				existsMsg = fmt.Sprintf("Done %s exists and has source duration %f", dstFile, srcDuration)
+				log.Printf(existsMsg)
+				return existsMsg, nil, false
+			} else {
+				msg := fmt.Sprintf("%s Existed but did NOT have the same duration src(%f) vs dst(%f)", dstFile, srcDuration, dstDuration)
+				log.Printf(msg)
+				return msg, nil, true
+			}
+		}
+	}
+	msg := fmt.Sprintf("File will be converted from %s to %s\nOld File: %s\nNew File: %s", codecName, cfg.CodecForConversion, srcFile, dstFile)
+	return msg, nil, true
 }
 
-// Just rename to something with the previous extension stripped 
+// Just rename to something with the previous extension stripped
 func GetVideoConversionName(srcFile string) string {
-    path := filepath.Dir(srcFile)
-    filename := filepath.Base(srcFile)
-    ext := filepath.Ext(filename)
+	path := filepath.Dir(srcFile)
+	filename := filepath.Base(srcFile)
+	ext := filepath.Ext(filename)
 
-    cfg := GetCfg()
-    if cfg.EncodingDestination != "" {
-        path = cfg.EncodingDestination
-    }
-    stripExtension := regexp.MustCompile(fmt.Sprintf("%s$", ext))
-    newFilename := stripExtension.ReplaceAllString(filename, "_h256.mp4")
-    return filepath.Join(path, newFilename) 
+	cfg := GetCfg()
+	if cfg.EncodingDestination != "" {
+		path = cfg.EncodingDestination
+	}
+	stripExtension := regexp.MustCompile(fmt.Sprintf("%s$", ext))
+	newFilename := stripExtension.ReplaceAllString(filename, "_h256.mp4")
+	return filepath.Join(path, newFilename)
 }
 
 // This will check if we should convert the source file then run the ffmpeg converter
-// Returns 
-//  - (msg: string) : What happened in human readable form
-//  - (err: error) : did we hit a full error state
-//  - (encoded: bool) : Did actual encoding take place vs just 'should not do it (ie: already encoded)'
+// Returns
+//   - (msg: string) : What happened in human readable form
+//   - (err: error) : did we hit a full error state
+//   - (encoded: bool) : Did actual encoding take place vs just 'should not do it (ie: already encoded)'
 func ConvertVideoToH256(srcFile string, dstFile string) (string, error, bool) {
-    reason, err, shouldConvert := ShouldEncodeVideo(srcFile, dstFile)
-    if shouldConvert == false {
-        log.Printf("Not converting %s", reason)
-        return reason, err, shouldConvert
-    }
+	reason, err, shouldConvert := ShouldEncodeVideo(srcFile, dstFile)
+	if shouldConvert == false {
+		log.Printf("Not converting %s", reason)
+		return reason, err, shouldConvert
+	}
 
-    // If codec in list of conversion codecs, then do it
-    cfg := GetCfg()
-    log.Printf("About to convert %s to codec %s", reason, cfg.CodecForConversion)
-    encode_err := ffmpeg.Input(srcFile).
-        Output(dstFile, ffmpeg.KwArgs{"c:v": cfg.CodecForConversion, "tag:v": "hvc1"}).
+	// If codec in list of conversion codecs, then do it
+	cfg := GetCfg()
+	log.Printf("About to convert %s to codec %s", reason, cfg.CodecForConversion)
+	encode_err := ffmpeg.Input(srcFile).
+		Output(dstFile, ffmpeg.KwArgs{"c:v": cfg.CodecForConversion, "tag:v": "hvc1"}).
+		GlobalArgs("-loglevel", "quiet").
 		OverWriteOutput().ErrorToStdOut().Run()
 
-    if encode_err != nil {
-        log.Printf("Encoding error when actually running ffmpeg  %s", encode_err)
-        return "", encode_err, false
-    }
-    return "Success: " + reason, nil, true
+	if encode_err != nil {
+		log.Printf("Encoding error when actually running ffmpeg  %s", encode_err)
+		return "", encode_err, false
+	}
+	return "Success: " + reason, nil, true
 }


### PR DESCRIPTION
* Partial success would not re-encode
* This makes it check if there is ACTUALLY video and not just a file with that name.
* Quiet output from ffmpeg