### PR TITLE
#314 - Adding in a ReadOnly Flag for DB access and Memory Access.  Fixes image read speed.

### DIFF
--- a/actions/contents.go
+++ b/actions/contents.go
@@ -138,21 +138,23 @@ func (v ContentsResource) Update(c buffalo.Context) error {
 // Destroy deletes a Content from the DB. This function is mapped
 // to the path DELETE /contents/{content_id}
 func (v ContentsResource) Destroy(c buffalo.Context) error {
-	_, tx, err := managers.ManagerCanCUD(&c)
+	_, _, err := managers.ManagerCanCUD(&c)
 	if err != nil {
 		return err
 	}
-
 	// TODO: Manager should ABSOLUTELY be the thing doing updates etc.
 	// Allocate an empty Content
 	contentContainer := &models.Content{}
 
-	// To find the Content the parameter content_id is used.
-	if err := tx.Find(contentContainer, c.Param("content_id")); err != nil {
-		return c.Error(http.StatusNotFound, err)
-	}
-	if err := tx.Destroy(contentContainer); err != nil {
-		return err
+	id := c.Param("content_id")
+	man := managers.GetManager(&c)
+	content, err := man.DestroyContent(id)
+	if err != nil {
+		if content == nil {
+			return c.Error(http.StatusNotFound, err)
+		} else {
+			return c.Error(http.StatusBadRequest, err)
+		}
 	}
 	return c.Render(http.StatusOK, r.JSON(contentContainer))
 }

--- a/managers/helper.go
+++ b/managers/helper.go
@@ -78,14 +78,17 @@ func CreateInitialStructure(cfg *utils.DirConfigEntry) error {
 
 // Init a manager and pass it in or just do this via config value instead of a pass in
 func CreateAllPreviews(cm ContentManager) error {
-
     cnts, c_err := cm.ListContainers(0, 9001) // Might need to make this smarter :(
     if c_err != nil {
+        log.Printf("Failed to list all containers %s", c_err)
         return c_err
     }
     if len(*cnts) == 0 {
-        return errors.New("No Containers were found in the database")
+        msg := "No Containers were found in the manager"
+        log.Printf(msg)
+        return errors.New(msg)
     }
+    log.Printf("Found a number of containers %d", len(*cnts))
 
     err_msg := []string{}
     for _, cnt := range *cnts {

--- a/managers/manager.go
+++ b/managers/manager.go
@@ -42,8 +42,9 @@ type ContentManager interface {
 	ListContainers(page int, per_page int) (*models.Containers, error)
 	ListContainersFiltered(page int, per_page int, includeHidden bool) (*models.Containers, error)
 	ListContainersContext() (*models.Containers, error)
-	UpdateContainer(c *models.Container) error
+	UpdateContainer(c *models.Container) (*models.Container, error)
 	CreateContainer(c *models.Container) error
+	DestroyContainer(id string) (*models.Container, error)
 
 	// Content listing (why did I name it Content vs Media?)
 	GetContent(content_id uuid.UUID) (*models.Content, error)
@@ -54,6 +55,7 @@ type ContentManager interface {
 	SearchContent(search string, page int, per_page int, cId string, contentType string, includeHidden bool) (*models.Contents, int, error)
 	SearchContainers(search string, page int, per_page int, includeHidden bool) (*models.Containers, error)
 	UpdateContent(content *models.Content) error
+	DestroyContent(id string) (*models.Content, error)
 	CreateContent(mc *models.Content) error
 	GetPreviewForMC(mc *models.Content) (string, error)
 
@@ -65,6 +67,7 @@ type ContentManager interface {
 	GetScreen(psID uuid.UUID) (*models.Screen, error)
 	CreateScreen(s *models.Screen) error
 	UpdateScreen(s *models.Screen) error
+	DestroyScreen(id string) (*models.Screen, error)
 
 	// Tags listing
 	ListAllTags(page int, perPage int) (*models.Tags, error)

--- a/managers/manager_db_test.go
+++ b/managers/manager_db_test.go
@@ -3,10 +3,21 @@ package managers
 import (
 	"contented/models"
 	"contented/test_common"
+	"contented/utils"
 	"fmt"
 
 	"github.com/gobuffalo/pop/v6"
 )
+
+func (as *ActionSuite) Test_ReadOnly_Mode() {
+	cfg := test_common.InitFakeApp(true)
+	man := GetManagerActionSuite(cfg, as)
+	as.Equal(man.CanEdit(), true, "It should be able to edit")
+
+	cfg.ReadOnly = true
+	utils.SetCfg(*cfg)
+	as.Equal(man.CanEdit(), false, "We should not be able to edit now")
+}
 
 // A basic DB search (ilike matching)
 func (as *ActionSuite) Test_DbManagerSearch() {

--- a/managers/manager_memory.go
+++ b/managers/manager_memory.go
@@ -268,13 +268,13 @@ func (cm ContentManagerMemory) GetContent(mcID uuid.UUID) (*models.Content, erro
 }
 
 // If you already updated the container in memory you are done
-func (cm ContentManagerMemory) UpdateContainer(c *models.Container) error {
+func (cm ContentManagerMemory) UpdateContainer(c *models.Container) (*models.Container, error) {
 	// TODO: Validate that this updates the actual reference in mem storage
 	if _, ok := cm.ValidContainers[c.ID]; ok {
 		cm.ValidContainers[c.ID] = *c
-		return nil
+		return c, nil
 	}
-	return errors.New("Container was not found to update")
+	return nil, errors.New("Container was not found to update")
 }
 
 // No updates should be allowed for memory management.
@@ -544,6 +544,18 @@ func (cm ContentManagerMemory) CreateContent(mc *models.Content) error {
 		return nil
 	}
 	return errors.New("ContentManagerMemory no contentinstance was passed in to CreateContent")
+}
+
+func (cm ContentManagerMemory) DestroyContent(id string) (*models.Content, error) {
+	return nil, errors.New("Not Implemented")
+}
+
+func (cm ContentManagerMemory) DestroyContainer(id string) (*models.Container, error) {
+	return nil, errors.New("Not Implemented")
+}
+
+func (cm ContentManagerMemory) DestroyScreen(id string) (*models.Screen, error) {
+	return nil, errors.New("Not Implemented")
 }
 
 // Note that we need to lock this down so that it cannot just access arbitrary files

--- a/utils/config.go
+++ b/utils/config.go
@@ -88,6 +88,7 @@ type DirConfigEntry struct {
 	CoreCount          int    // How many cores are likely available (used in creating multithread workers / previews)
 	StaticResourcePath string // The location where compiled js and css is hosted (container vs dev server)
 	StaticLibraryPath  string // Library includes (monaco just doesn't want to build in)
+	ReadOnly           bool   // Can you edit content on this site
 	Initialized        bool   // Has the configuration actually be initialized properly
 
 	// Config around creating preview images (used only by the task db:preview)
@@ -227,6 +228,7 @@ func InitConfigEnvy(cfg *DirConfigEntry) *DirConfigEntry {
 
 	previewNumberOfScreens, totalScreenErr := strconv.Atoi(envy.Get("TOTAL_SCREENS", strconv.Itoa(DefeaultTotalScreens)))
 	previewFirstScreenOffset, offsetErr := strconv.Atoi(envy.Get("FIRST_SCREEN_OFFSET", strconv.Itoa(DefaultPreviewFirstScreenOffset)))
+	readOnly, rOnlyErr := strconv.ParseBool(envy.Get("READ_ONLY", "false"))
 
 	if err != nil {
 		panic(err)
@@ -256,6 +258,8 @@ func InitConfigEnvy(cfg *DirConfigEntry) *DirConfigEntry {
 		panic(totalScreenErr)
 	} else if (offsetErr) != nil {
 		panic(offsetErr)
+	} else if (rOnlyErr) != nil {
+		panic(rOnlyErr)
 	}
 
 	if !(previewType == "png" || previewType == "gif" || previewType == "screens") {
@@ -276,6 +280,7 @@ func InitConfigEnvy(cfg *DirConfigEntry) *DirConfigEntry {
 	cfg.PreviewNumberOfScreens = previewNumberOfScreens
 	cfg.PreviewFirstScreenOffset = previewFirstScreenOffset
 
+	cfg.ReadOnly = readOnly
 	cfg.IncludeOperator = envy.Get("INCLUDE_OPERATOR", "AND")
 	cfg.ExcludeOperator = envy.Get("EXCLUDE_OPERATOR", "AND")
 


### PR DESCRIPTION
* Cleans up some of the actions
* Cleans up a bunch of the other action endpoints
* Image.Probe is too slow, swapped to use ProbeConfig for images.