### PR TITLE
#309 - Add tagging support to the memory manager and unit test.

### DIFF
--- a/managers/manager_db.go
+++ b/managers/manager_db.go
@@ -486,7 +486,6 @@ func (cm ContentManagerDB) GetValidTags(tags *models.Tags) (*models.Tags, error)
 func (cm ContentManagerDB) AssociateTag(t *models.Tag, mc *models.Content) error {
 	// TODO: Could require [Tags] and not do the append with this function
 	tx := cm.GetConnection()
-
 	tags := models.Tags{}
 	if mc.Tags != nil {
 		tags = mc.Tags

--- a/managers/manager_memory_test.go
+++ b/managers/manager_memory_test.go
@@ -360,3 +360,28 @@ func (as *ActionSuite) Test_ManagerMemoryCRU() {
 	as.NoError(scErr, "Failed to get the screen back")
 	as.Equal(s1Check.Path, "C")
 }
+
+func (as *ActionSuite) Test_MemoryManagerTags() {
+	test_common.InitFakeApp(false)
+	ctx := test_common.GetContext(as.App)
+	man := GetManager(&ctx)
+
+	aTag := models.Tag{ID: "A"}
+	bTag := models.Tag{ID: "B"}
+	as.NoError(man.CreateTag(&aTag))
+	as.NoError(man.CreateTag(&bTag))
+
+	content := models.Content{Src: "SomethingSomethingDarkside", NoFile: true}
+	as.NoError(man.CreateContent(&content))
+
+	as.NoError(man.AssociateTagByID(aTag.ID, content.ID))
+	as.NoError(man.AssociateTagByID(bTag.ID, content.ID))
+	checkContent, err := man.GetContent(content.ID)
+	as.NoError(err)
+	as.NotEmpty(checkContent.Tags, "We should have tags")
+	as.Equal(len(checkContent.Tags), 2, "There should be two tags")
+
+	// Not in the DB so should not associate
+	notExistsTag := models.Tag{ID: "NOPE"}
+	as.Error(man.AssociateTagByID(notExistsTag.ID, content.ID))
+}


### PR DESCRIPTION
* The memory manager does not have a clever lookup by tag yet but at least not they can associate
* Adds tests around the creation, and association of some basic tagging in the system.