### PR TITLE
#318 - Enables Memory manager write mode and also Tag Search.

### DIFF
--- a/actions/containers.go
+++ b/actions/containers.go
@@ -95,14 +95,14 @@ func (v ContainersResource) Update(c buffalo.Context) error {
 	// Get the DB connection from the context
 	_, _, err := managers.ManagerCanCUD(&c)
 	if err != nil {
-		return err
+		return c.Error(http.StatusNotImplemented, err)
 	}
 
 	// Allocate an empty Container
 	man := managers.GetManager(&c)
 	id, idErr := uuid.FromString(c.Param("container_id"))
 	if idErr != nil {
-		return idErr
+		return c.Error(http.StatusBadRequest, idErr)
 	}
 	// Bind Container to the html form elements (could toss the context into the manager)
 	cnt, notFoundErr := man.GetContainer(id)
@@ -110,11 +110,11 @@ func (v ContainersResource) Update(c buffalo.Context) error {
 		return c.Error(http.StatusNotFound, notFoundErr)
 	}
 	if err := c.Bind(cnt); err != nil {
-		return err
+		return c.Error(http.StatusBadRequest, err)
 	}
 	upCnt, upErr := man.UpdateContainer(cnt)
 	if upErr != nil {
-		return upErr
+		return c.Error(http.StatusInternalServerError, upErr)
 	}
 	return c.Render(http.StatusOK, r.JSON(upCnt))
 }

--- a/actions/containers_test.go
+++ b/actions/containers_test.go
@@ -82,9 +82,10 @@ func (as *ActionSuite) Test_ContainersResource_Update() {
 	name := "UpdateTest"
 	cnt.Name = name
 	test_common.CreateContainerPath(&cnt)
+
 	res := as.JSON("/containers/" + cnt.ID.String()).Put(cnt)
 	defer test_common.CleanupContainer(&cnt)
-	as.Equal(http.StatusOK, res.Code)
+	as.Equal(http.StatusOK, res.Code, fmt.Sprintf("Error %s", res.Body.String()))
 
 	check := models.Container{}
 	json.NewDecoder(res.Body).Decode(&check)

--- a/actions/containers_test.go
+++ b/actions/containers_test.go
@@ -131,14 +131,14 @@ func (as *ActionSuite) Test_ContainerList() {
 	as.Equal(http.StatusOK, contentRes.Code)
 }
 
-func (as *ActionSuite) Test_MemoryDenyEdit() {
-	test_common.InitFakeApp(false)
+func (as *ActionSuite) Test_Memory_ReadOnlyDenyEdit() {
+	cfg := test_common.InitFakeApp(false)
+	cfg.ReadOnly = true
 	ctx := test_common.GetContext(as.App)
 	man := managers.GetManager(&ctx)
 
 	containers, err := man.ListContainersContext()
 	as.NoError(err, "It should list containers")
-
 	as.Greater(len(*containers), 0, "There should be containers")
 
 	for _, c := range *containers {

--- a/actions/screens_test.go
+++ b/actions/screens_test.go
@@ -1,157 +1,157 @@
 package actions
 
 import (
-    "fmt"
-    "net/http"
-    "os"
-    //    "net/url"
-    "contented/test_common"
-    "contented/models"
-    "encoding/json"
-    "github.com/gobuffalo/nulls"
-    "github.com/gofrs/uuid"
-    "path/filepath"
+	"fmt"
+	"net/http"
+	"os"
+
+	//    "net/url"
+	"contented/models"
+	"contented/test_common"
+	"encoding/json"
+	"path/filepath"
+
+	"github.com/gobuffalo/nulls"
+	"github.com/gofrs/uuid"
 )
 
 func CreatePreview(src string, contentID uuid.UUID, as *ActionSuite) models.Screen {
-    mc := &models.Screen{
-        Src:     src,
-        ContentID: contentID,
-        Idx:     1,
-    }
-    res := as.JSON("/screens").Post(mc)
-    as.Equal(http.StatusCreated, res.Code)
+	mc := &models.Screen{
+		Src:       src,
+		ContentID: contentID,
+		Idx:       1,
+	}
+	res := as.JSON("/screens").Post(mc)
+	as.Equal(http.StatusCreated, res.Code)
 
-    resObj := models.Screen{}
-    json.NewDecoder(res.Body).Decode(&resObj)
-    return resObj
+	resObj := models.Screen{}
+	json.NewDecoder(res.Body).Decode(&resObj)
+	return resObj
 
 }
 
 // Kind of a pain in the ass to create all the way down to a valid preview screen
 func CreateTestContainerWithContent(as *ActionSuite) (*models.Container, *models.Content, string) {
-    srcDir, dstDir, testFile := test_common.Get_VideoAndSetupPaths()
-    c := &models.Container{
-        Total: 4,
-        Path:  filepath.Dir(srcDir),
-        Name:  filepath.Base(srcDir),
-    }
-    as.DB.Create(c)
+	srcDir, dstDir, testFile := test_common.Get_VideoAndSetupPaths()
+	c := &models.Container{
+		Total: 4,
+		Path:  filepath.Dir(srcDir),
+		Name:  filepath.Base(srcDir),
+	}
+	as.DB.Create(c)
 
-    // TODO: Ensure that this path is actually correct, should actually make a REAL jpeg copy
-    screenSrc := filepath.Join(dstDir, fmt.Sprintf("%s.screen.001.jpg", testFile))
-    mc := &models.Content{
-        Src:         testFile,
-        ContentType: "video/mp4",
-        Preview:     screenSrc,
-        ContainerID: nulls.NewUUID(c.ID),
-    }
-    as.DB.Create(mc)
+	// TODO: Ensure that this path is actually correct, should actually make a REAL jpeg copy
+	screenSrc := filepath.Join(dstDir, fmt.Sprintf("%s.screen.001.jpg", testFile))
+	mc := &models.Content{
+		Src:         testFile,
+		ContentType: "video/mp4",
+		Preview:     screenSrc,
+		ContainerID: nulls.NewUUID(c.ID),
+	}
+	as.DB.Create(mc)
 
-    fmt.Printf("Screen src %s", screenSrc)
-    f, err := os.Create(screenSrc)
-    if err != nil {
-        as.T().Errorf("Couldn't write to %s", screenSrc)
-    }
-    _, wErr := f.WriteString("Totally a screen")
-    if wErr != nil {
-        as.T().Errorf("Create a fake screen file on disk %s", screenSrc)
-    }
-    f.Sync()
-    f.Close()
-    return c, mc, screenSrc
+	fmt.Printf("Screen src %s", screenSrc)
+	f, err := os.Create(screenSrc)
+	if err != nil {
+		as.T().Errorf("Couldn't write to %s", screenSrc)
+	}
+	_, wErr := f.WriteString("Totally a screen")
+	if wErr != nil {
+		as.T().Errorf("Create a fake screen file on disk %s", screenSrc)
+	}
+	f.Sync()
+	f.Close()
+	return c, mc, screenSrc
 }
 
 func CreateScreen(as *ActionSuite) (*models.Container, *models.Content, *models.Screen) {
-    c, mc, screenSrc := CreateTestContainerWithContent(as)
-    ps := CreatePreview(screenSrc, mc.ID, as)
-    return c, mc, &ps
+	c, mc, screenSrc := CreateTestContainerWithContent(as)
+	ps := CreatePreview(screenSrc, mc.ID, as)
+	return c, mc, &ps
 }
 
 func (as *ActionSuite) Test_ScreensResource_List() {
-    test_common.InitFakeApp(true)
-    CreateScreen(as)
-    CreateScreen(as)
+	test_common.InitFakeApp(true)
+	CreateScreen(as)
+	CreateScreen(as)
 
-    res := as.JSON("/screens/").Get()
-    as.Equal(http.StatusOK, res.Code)
+	res := as.JSON("/screens/").Get()
+	as.Equal(http.StatusOK, res.Code)
 
-    validate := models.Screens{}
-    json.NewDecoder(res.Body).Decode(&validate)
-    as.Equal(len(validate), 2, "There should be two preview screens")
+	validate := models.Screens{}
+	json.NewDecoder(res.Body).Decode(&validate)
+	as.Equal(len(validate), 2, "There should be two preview screens")
 }
 
 func (as *ActionSuite) Test_ScreensResource_ListMC() {
-    test_common.InitFakeApp(true)
+	test_common.InitFakeApp(true)
 
-    // This creates a preview screen making the total 3 in the DB
-    // Note it also resets the container_preview dir right now
-    CreateScreen(as)
+	// This creates a preview screen making the total 3 in the DB
+	// Note it also resets the container_preview dir right now
+	CreateScreen(as)
 
-    _, mc1, _ := CreateScreen(as)
-    CreatePreview("A", mc1.ID, as)
-    res := as.JSON(fmt.Sprintf("/content/%s/screens", mc1.ID.String())).Get()
-    as.Equal(http.StatusOK, res.Code)
+	_, mc1, _ := CreateScreen(as)
+	CreatePreview("A", mc1.ID, as)
+	res := as.JSON(fmt.Sprintf("/content/%s/screens", mc1.ID.String())).Get()
+	as.Equal(http.StatusOK, res.Code)
 
-    validate := models.Screens{}
-    json.NewDecoder(res.Body).Decode(&validate)
-    as.Equal(len(validate), 2, "Note we should have only two screens")
-    for _, ps := range validate {
-        as.Equal(ps.ContentID, mc1.ID)
-        as.Equal(ps.Path, "") // Path should not be visible in the API
-    }
+	validate := models.Screens{}
+	json.NewDecoder(res.Body).Decode(&validate)
+	as.Equal(len(validate), 2, "Note we should have only two screens")
+	for _, ps := range validate {
+		as.Equal(ps.ContentID, mc1.ID)
+		as.Equal(ps.Path, "") // Path should not be visible in the API
+	}
 }
 
 func (as *ActionSuite) Test_ScreensResource_Show() {
-    test_common.InitFakeApp(true)
-    _, _, ps := CreateScreen(as)
+	test_common.InitFakeApp(true)
+	_, _, ps := CreateScreen(as)
 
-    res := as.JSON(fmt.Sprintf("/screens/%s", ps.ID.String())).Get()
-    as.Equal(http.StatusOK, res.Code)
+	res := as.JSON(fmt.Sprintf("/screens/%s", ps.ID.String())).Get()
+	as.Equal(http.StatusOK, res.Code)
 
-    // Need to make it host the file.
-    header := res.Header()
-    as.Equal("image/jpeg", header.Get("Content-Type"))
+	// Need to make it host the file.
+	header := res.Header()
+	as.Equal("image/jpeg", header.Get("Content-Type"))
 }
 
 // TODO: Create a screen that is actually on disk.
 func (as *ActionSuite) Test_ScreensResource_Create() {
-    test_common.InitFakeApp(true)
-    _, mc, screenSrc := CreateTestContainerWithContent(as)
-    ps := CreatePreview(screenSrc, mc.ID, as)
-    as.Equal(ps.Src, screenSrc)
+	test_common.InitFakeApp(true)
+	_, mc, screenSrc := CreateTestContainerWithContent(as)
+	ps := CreatePreview(screenSrc, mc.ID, as)
+	as.Equal(ps.Src, screenSrc)
 
-    screens := models.Screens{}
-    as.DB.Where("content_id = ?", mc.ID).All(&screens)
-    as.Equal(len(screens), 1, "There should be a screen in the DB")
+	screens := models.Screens{}
+	as.DB.Where("content_id = ?", mc.ID).All(&screens)
+	as.Equal(len(screens), 1, "There should be a screen in the DB")
 }
 
 func (as *ActionSuite) Test_ScreensResource_Update() {
-    test_common.InitFakeApp(true)
-    _, mc, screenSrc := CreateTestContainerWithContent(as)
-    ps := CreatePreview(screenSrc, mc.ID, as)
-    ps.Src = "UP"
-    res := as.JSON(fmt.Sprintf("/screens/%s", ps.ID.String())).Put(ps)
-    as.Equal(http.StatusOK, res.Code)
+	test_common.InitFakeApp(true)
+	_, mc, screenSrc := CreateTestContainerWithContent(as)
+	ps := CreatePreview(screenSrc, mc.ID, as)
+	ps.Src = "UP"
+	res := as.JSON(fmt.Sprintf("/screens/%s", ps.ID.String())).Put(ps)
+	as.Equal(http.StatusOK, res.Code)
 }
 
 func (as *ActionSuite) Test_ScreensResource_Destroy() {
-    test_common.InitFakeApp(true)
-    _, mc, screenSrc := CreateTestContainerWithContent(as)
-    ps := CreatePreview(screenSrc, mc.ID, as)
+	test_common.InitFakeApp(true)
+	_, mc, screenSrc := CreateTestContainerWithContent(as)
+	ps := CreatePreview(screenSrc, mc.ID, as)
 
-    fmt.Printf("What the fuck %s", ps.ID.String())
-
-    del_res := as.JSON(fmt.Sprintf("/screens/%s", ps.ID.String())).Delete()
-    as.Equal(http.StatusOK, del_res.Code)
+	del_res := as.JSON(fmt.Sprintf("/screens/%s", ps.ID.String())).Delete()
+	as.Equal(http.StatusOK, del_res.Code)
 }
 
-func (as *ActionSuite) Test_ScreensResource_CannotDestroy() {
-    test_common.InitFakeApp(false)
-    ps := &models.Screen{
-        Src: "Shouldn't Allow Create",
-        Idx: 1,
-    }
-    res := as.JSON("/screens/").Post(ps)
-    as.Equal(http.StatusNotImplemented, res.Code)
+func (as *ActionSuite) Test_ScreensResource_CannotCreate() {
+	test_common.InitFakeApp(false)
+	ps := &models.Screen{
+		Src: "Shouldn't Allow Create",
+		Idx: 1,
+	}
+	res := as.JSON("/screens/").Post(ps)
+	as.Equal(http.StatusCreated, res.Code)
 }

--- a/managers/manager.go
+++ b/managers/manager.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/gobuffalo/buffalo"
 	"github.com/gobuffalo/pop/v6"
@@ -39,7 +40,7 @@ type SearchRequest struct {
 }
 
 func (sr SearchRequest) String() string {
-	s, _ := json.MarshalIndent(sr, "SearchRequest", "  ")
+	s, _ := json.MarshalIndent(sr, "", "  ")
 	return string(s)
 }
 
@@ -220,6 +221,11 @@ func ContextToSearchRequest(params pop.PaginationParams, cfg *utils.DirConfigEnt
 		PerPage:     per_page,
 		Page:        page,
 		Hidden:      false,
+	}
+
+	tagStr := StringDefault(params.Get("tags"), "")
+	if tagStr != "" {
+		sReq.Tags = strings.Split(tagStr, ",")
 	}
 	return sReq
 }

--- a/managers/manager_db.go
+++ b/managers/manager_db.go
@@ -156,6 +156,11 @@ func (cm ContentManagerDB) SearchContent(sr SearchRequest) (*models.Contents, in
 	contentContainers := &models.Contents{}
 	tx := cm.GetConnection()
 	q := tx.Paginate(sr.Page, sr.PerPage)
+
+	if len(sr.Tags) > 0 {
+		q = q.Join("contents_tags as ct", "ct.content_id = contents.id").Where("ct.tag_id IN (?)", sr.Tags)
+	}
+	// Could also search description
 	if sr.Text != "*" && sr.Text != "" {
 		search := ("%" + sr.Text + "%")
 		q = q.Where(`src like ?`, search)
@@ -525,8 +530,6 @@ func (cm ContentManagerDB) AssociateTagByID(tagId string, mcID uuid.UUID) error 
 	return cm.AssociateTag(t, mc)
 }
 
-// TODO: Security vuln need to ensure that you can only create UNDER the directory
-// specified by the initial load.  The same thing must happen on update.
 // TODO: Should we be able to CREATE actual directory information under the
 // parent container if it does not exist?
 func (cm ContentManagerDB) CreateContainer(c *models.Container) error {

--- a/managers/manager_db_test.go
+++ b/managers/manager_db_test.go
@@ -47,23 +47,28 @@ func (as *ActionSuite) Test_DbManagerSearch() {
 			man.CreateScreen(&models.Screen{ContentID: mc.ID, Src: "screen2"})
 		}
 	}
-	mcs, _, err := man.SearchContent("Large", 1, 20, "", "", false)
+
+	sr := SearchRequest{Text: "Large", Page: 1, PerPage: 20}
+	mcs, _, err := man.SearchContent(sr)
 	as.NoError(err, "It should be able to search")
 	as.NotNil(mcs, "It should be")
 	as.Equal(3, len(*mcs), fmt.Sprintf("We should have 3 large images with an ilike %s", mcs))
 
-	mcs_d, vsTotal, vErr := man.SearchContent("donut", 1, 10, "", "", false)
+	sr = SearchRequest{Text: "donut", Page: 1, PerPage: 10}
+	mcs_d, vsTotal, vErr := man.SearchContent(sr)
 	as.NoError(vErr, "Video error by name search failed")
 	as.Equal(1, vsTotal, "We should be able to find donut.mp4 with an ilike")
 	mc_donut := (*mcs_d)[0]
 	as.Equal(2, len(mc_donut.Screens), fmt.Sprintf("It should load two screens %s", mc_donut.Screens))
 
-	vids, vidTotal, dbErr := man.SearchContent("", 1, 40, "", "video", false)
+	sr = SearchRequest{Page: 1, PerPage: 40, ContentType: "video"}
+	vids, vidTotal, dbErr := man.SearchContent(sr)
 	as.NoError(dbErr, "Should search content type")
 	as.Equal(1, vidTotal, "The total count for videos is 1")
 	as.Equal(1, len(*vids), "We should have one result")
 
-	all_mcs, total, err := man.SearchContent("", 1, 10, cnt1.ID.String(), "", false)
+	sr = SearchRequest{Page: 1, PerPage: 10, ContainerID: cnt1.ID.String()}
+	all_mcs, total, err := man.SearchContent(sr)
 	as.NoError(err, "It should be able to empty search")
 	as.Equal(12, total, "The total count for this dir is 12")
 	as.Equal(10, len(*all_mcs), "But we limited the pagination")
@@ -86,16 +91,19 @@ func (as *ActionSuite) Test_DbManagerMultiSearch() {
 	as.NoError(err2)
 	as.Greater(len(content2), 1)
 
-	found, count, err := man.SearchContent(content1[1].Src, 0, 10, cnt1.ID.String(), "", false)
+	sr := SearchRequest{Text: content1[1].Src, PerPage: 10, ContainerID: cnt1.ID.String()}
+	found, count, err := man.SearchContent(sr)
 	as.Equal(len(*found), 1, "We should have found our item")
 	as.Equal(count, 1)
 	as.NoError(err)
 
-	_, n_count, n_err := man.SearchContent("blah", 0, 10, cnt1.ID.String(), "", false)
+	sr = SearchRequest{Text: "blah", ContainerID: cnt1.ID.String()}
+	_, n_count, n_err := man.SearchContent(sr)
 	as.Equal(n_count, 0, "It should not find this the content name is invalid")
 	as.NoError(n_err)
+	sr = SearchRequest{Text: content1[1].Src, ContainerID: cnt2.ID.String()}
 
-	_, not_in_cnt_count, not_err := man.SearchContent(content1[1].Src, 0, 10, cnt2.ID.String(), "", false)
+	_, not_in_cnt_count, not_err := man.SearchContent(sr)
 	as.Equal(not_in_cnt_count, 0, "It should not find this valid content as it is not in the container")
 	as.NoError(not_err)
 }

--- a/managers/manager_db_test.go
+++ b/managers/manager_db_test.go
@@ -159,7 +159,7 @@ func (as *ActionSuite) Test_ManagerTagsDB_CRUD() {
 	as.Equal(len(*tags_gone), 0, "No tags should be in the DB")
 }
 
-func (as *ActionSuite) Test_ManagerAssociateTagsDB() {
+func (as *ActionSuite) Test_DbManager_AssociateTags() {
 	models.DB.TruncateAll()
 	cfg := test_common.InitFakeApp(true)
 	man := GetManagerActionSuite(cfg, as)
@@ -196,6 +196,43 @@ func (as *ActionSuite) Test_ManagerAssociateTagsDB() {
 	mcCheck, mc_err := man.GetContent(mc.ID)
 	as.NoError(mc_err, fmt.Sprintf("We should be able to load back the content %s", err))
 	as.Equal(3, len(mcCheck.Tags), fmt.Sprintf("There should be a new tag %s", mcCheck))
+}
+
+// A Lot more of these could be a test in manager that passes in the manager
+// TODO: Remove copy pasta and make it almost identical.
+func (as *ActionSuite) Test_DbManager_TagSearch() {
+	models.DB.TruncateAll()
+	cfg := test_common.InitFakeApp(true)
+
+	man := GetManagerActionSuite(cfg, as)
+	as.NoError(man.CreateTag(&models.Tag{ID: "A"}))
+	as.NoError(man.CreateTag(&models.Tag{ID: "B"}))
+	as.NoError(man.CreateTag(&models.Tag{ID: "OR"}))
+
+	a := &models.Content{NoFile: true, Src: "AFile"}
+	b := &models.Content{NoFile: true, Src: "BFile"}
+	as.NoError(man.CreateContent(a))
+	as.NoError(man.CreateContent(b))
+
+	as.NoError(man.AssociateTagByID("A", a.ID))
+	as.NoError(man.AssociateTagByID("B", b.ID))
+	as.NoError(man.AssociateTagByID("OR", b.ID))
+
+	_, count, err := man.SearchContent(SearchRequest{})
+	as.NoError(err, "It should search empty content")
+	as.Equal(count, 2, "And return all the contents")
+
+	_, tCount, tErr := man.SearchContent(SearchRequest{Tags: []string{"A"}, Text: "File"})
+	as.NoError(tErr, "A tag join shouldn't explode")
+	as.Equal(tCount, 1, "And it should only get A Back")
+
+	_, orCount, orErr := man.SearchContent(SearchRequest{Tags: []string{"OR", "A"}})
+	as.NoError(orErr, "A tag join shouldn't explode")
+	as.Equal(orCount, 2, "And it should get both objects Back")
+
+	_, noCount, noErr := man.SearchContent(SearchRequest{Tags: []string{"A"}, Text: "YAAARG"})
+	as.NoError(noErr, "It should not error")
+	as.Equal(noCount, 0, "But it shouldn't match the text")
 }
 
 func (as *ActionSuite) Test_ManagerDBPreviews() {

--- a/managers/manager_db_test.go
+++ b/managers/manager_db_test.go
@@ -205,34 +205,7 @@ func (as *ActionSuite) Test_DbManager_TagSearch() {
 	cfg := test_common.InitFakeApp(true)
 
 	man := GetManagerActionSuite(cfg, as)
-	as.NoError(man.CreateTag(&models.Tag{ID: "A"}))
-	as.NoError(man.CreateTag(&models.Tag{ID: "B"}))
-	as.NoError(man.CreateTag(&models.Tag{ID: "OR"}))
-
-	a := &models.Content{NoFile: true, Src: "AFile"}
-	b := &models.Content{NoFile: true, Src: "BFile"}
-	as.NoError(man.CreateContent(a))
-	as.NoError(man.CreateContent(b))
-
-	as.NoError(man.AssociateTagByID("A", a.ID))
-	as.NoError(man.AssociateTagByID("B", b.ID))
-	as.NoError(man.AssociateTagByID("OR", b.ID))
-
-	_, count, err := man.SearchContent(SearchRequest{})
-	as.NoError(err, "It should search empty content")
-	as.Equal(count, 2, "And return all the contents")
-
-	_, tCount, tErr := man.SearchContent(SearchRequest{Tags: []string{"A"}, Text: "File"})
-	as.NoError(tErr, "A tag join shouldn't explode")
-	as.Equal(tCount, 1, "And it should only get A Back")
-
-	_, orCount, orErr := man.SearchContent(SearchRequest{Tags: []string{"OR", "A"}})
-	as.NoError(orErr, "A tag join shouldn't explode")
-	as.Equal(orCount, 2, "And it should get both objects Back")
-
-	_, noCount, noErr := man.SearchContent(SearchRequest{Tags: []string{"A"}, Text: "YAAARG"})
-	as.NoError(noErr, "It should not error")
-	as.Equal(noCount, 0, "But it shouldn't match the text")
+	ManagersTagSearchValidation(as, man)
 }
 
 func (as *ActionSuite) Test_ManagerDBPreviews() {

--- a/managers/manager_memory_test.go
+++ b/managers/manager_memory_test.go
@@ -72,6 +72,7 @@ func (as *ActionSuite) Test_AssignManager() {
 func (as *ActionSuite) Test_MemoryManagerPaginate() {
 	cfg := test_common.InitFakeApp(false)
 	cfg.UseDatabase = false
+	cfg.ReadOnly = true
 
 	ctx := test_common.GetContextParams(as.App, "/containers", "1", "2")
 	man := GetManager(&ctx)
@@ -163,12 +164,13 @@ func (as *ActionSuite) Test_MemoryManagerSearch() {
 func (as *ActionSuite) Test_MemoryManagerSearchMulti() {
 	// Test that a search restricting containerID works
 	// Test that search restricting container and text works
-	test_common.InitFakeApp(false)
+	cfg := test_common.InitFakeApp(false)
+	cfg.ReadOnly = false
 	ctx := test_common.GetContext(as.App)
 	man := GetManager(&ctx)
 
 	// Ensure we initialized with a known search
-	as.Equal(man.CanEdit(), false)
+	as.Equal(man.CanEdit(), true)
 	sr := SearchRequest{Text: "donut"}
 	mcs, total, err := man.SearchContent(sr)
 	as.NoError(err, "Can we search in the memory manager")
@@ -268,13 +270,21 @@ func (as *ActionSuite) Test_MemoryPreviewInitialization() {
 }
 
 func (as *ActionSuite) Test_ManagerTagsMemory() {
-	cfg := test_common.InitFakeApp(false)
+	cfg := test_common.InitMemoryFakeAppEmpty()
 	man := GetManagerActionSuite(cfg, as)
 	as.NoError(man.CreateTag(&models.Tag{ID: "A"}), "couldn't create tag A")
 	as.NoError(man.CreateTag(&models.Tag{ID: "B"}), "couldn't create tag B")
 	tags, err := man.ListAllTags(0, 3)
 	as.NoError(err, "It should be able to list tags")
 	as.Equal(len(*tags), 2, "We should have two tags")
+}
+
+// A Lot more of these could be a test in manager that passes in the manager
+// TODO: Remove copy pasta and make it almost identical.
+func (as *ActionSuite) Test_MemoryManager_TagSearch() {
+	cfg := test_common.InitMemoryFakeAppEmpty()
+	man := GetManagerActionSuite(cfg, as)
+	ManagersTagSearchValidation(as, man)
 }
 
 func (as *ActionSuite) Test_MangerTagsMemoryCRUD() {

--- a/managers/managers_test.go
+++ b/managers/managers_test.go
@@ -28,11 +28,10 @@ func GetManagerActionSuite(cfg *utils.DirConfigEntry, as *ActionSuite) ContentMa
 	return CreateManager(cfg, get_conn, get_params)
 }
 
-// Why are no tests working?
 func TestMain(m *testing.M) {
 	_, err := envy.MustGet("DIR")
 	if err != nil {
-		log.Println("DIR ENV REQUIRED$ export=DIR=`pwd`/mocks/content/ && buffalo test")
+		log.Println("DIR ENV REQUIRED ie: $export=DIR=`pwd`/mocks/content/ && buffalo test")
 		panic(err)
 	}
 	code := m.Run()
@@ -46,4 +45,35 @@ func Test_ManagerSuite(t *testing.T) {
 		Action: action,
 	}
 	suite.Run(t, as)
+}
+
+func ManagersTagSearchValidation(as *ActionSuite, man ContentManager) {
+	as.NoError(man.CreateTag(&models.Tag{ID: "A"}))
+	as.NoError(man.CreateTag(&models.Tag{ID: "B"}))
+	as.NoError(man.CreateTag(&models.Tag{ID: "OR"}))
+
+	a := &models.Content{NoFile: true, Src: "AFile"}
+	b := &models.Content{NoFile: true, Src: "BFile"}
+	as.NoError(man.CreateContent(a))
+	as.NoError(man.CreateContent(b))
+
+	as.NoError(man.AssociateTagByID("A", a.ID))
+	as.NoError(man.AssociateTagByID("B", b.ID))
+	as.NoError(man.AssociateTagByID("OR", b.ID))
+
+	_, count, err := man.SearchContent(SearchRequest{})
+	as.NoError(err, "It should search empty content")
+	as.Equal(count, 2, "And return all the contents")
+
+	_, tCount, tErr := man.SearchContent(SearchRequest{Tags: []string{"A"}, Text: "File"})
+	as.NoError(tErr, "A tag join shouldn't explode")
+	as.Equal(tCount, 1, "And it should only get A Back")
+
+	_, orCount, orErr := man.SearchContent(SearchRequest{Tags: []string{"OR", "A"}})
+	as.NoError(orErr, "A tag join shouldn't explode")
+	as.Equal(orCount, 2, "And it should get both objects Back")
+
+	_, noCount, noErr := man.SearchContent(SearchRequest{Tags: []string{"A"}, Text: "YAAARG"})
+	as.NoError(noErr, "It should not error")
+	as.Equal(noCount, 0, "But it shouldn't match the text")
 }

--- a/models/container.go
+++ b/models/container.go
@@ -21,7 +21,7 @@ type Container struct {
 	Active    bool      `json:"active" db:"active" default:"true"`
 	Idx       int       `json:"idx" db:"idx" default:"0"`
 	Contents  Contents  `json:"contents" has_many:"contents" db:"-"`
-	Hidden    bool      `json:"-" db:"hidden" default:"true"`
+	Hidden    bool      `json:"-" db:"hidden" default:"false"`
 
 	// This is expected to be a URL where often a configured /preview/{mcID} is going
 	// to be assigned by default.  However you should be able to use any link but it is

--- a/models/container.go
+++ b/models/container.go
@@ -13,15 +13,15 @@ import (
 // Container is used by pop to map your containers database table to your go code.
 type Container struct {
 	ID        uuid.UUID `json:"id" db:"id"`
-	Total     int       `json:"total" db:"total"`
+	Total     int       `json:"total" db:"total" default:"0"`
 	Path      string    `json:"-" db:"path"`
 	Name      string    `json:"name" db:"name"`
 	CreatedAt time.Time `json:"created" db:"created_at"`
 	UpdatedAt time.Time `json:"updated" db:"updated_at"`
-	Active    bool      `json:"active" db:"active"`
-	Idx       int       `json:"idx" db:"idx"`
+	Active    bool      `json:"active" db:"active" default:"true"`
+	Idx       int       `json:"idx" db:"idx" default:"0"`
 	Contents  Contents  `json:"contents" has_many:"contents" db:"-"`
-	Hidden    bool      `json:"-" db:"hidden"`
+	Hidden    bool      `json:"-" db:"hidden" default:"true"`
 
 	// This is expected to be a URL where often a configured /preview/{mcID} is going
 	// to be assigned by default.  However you should be able to use any link but it is

--- a/models/content.go
+++ b/models/content.go
@@ -20,16 +20,16 @@ type Content struct {
 	ContentType string     `json:"content_type" db:"content_type"`
 	Preview     string     `json:"preview" db:"preview"`
 	ContainerID nulls.UUID `json:"container_id" db:"container_id"`
-	Idx         int        `json:"idx" db:"idx"`
-	Active      bool       `json:"active" db:"active"`
-	Corrupt     bool       `json:"corrupt" db:"corrupt"`
-	SizeBytes   int64      `json:"size" db:"size_bytes"`
-	Description string     `json:"description" db:"description"`
-	NoFile      bool       `json:"no_file" db:"no_file"` // Actual file or just description etc
-	Hidden      bool       `json:"-" db:"hidden"`        // Should it be visible in basic list queries
+	Idx         int        `json:"idx" db:"idx" default:"0"`
+	Active      bool       `json:"active" db:"active" default:"true"`
+	Corrupt     bool       `json:"corrupt" db:"corrupt" default:"false"`
+	SizeBytes   int64      `json:"size" db:"size_bytes" default:"0"`
+	Description string     `json:"description" db:"description" default:""`
+	NoFile      bool       `json:"no_file" db:"no_file" default:"false"` // Actual file or just description etc
+	Hidden      bool       `json:"-" db:"hidden" default:"false"`        // Should it be visible in basic list queries
 
 	// This is for information about the file content (video / image mostly stats, rez etc)
-	Meta string `json:"meta" db:"meta"`
+	Meta string `json:"meta" db:"meta" default:""`
 
 	// Joins (Eager loading is not working?)
 	Screens Screens `json:"screens" has_many:"preview_screens"`

--- a/models/content.go
+++ b/models/content.go
@@ -73,3 +73,18 @@ func (m *Content) ValidateCreate(tx *pop.Connection) (*validate.Errors, error) {
 func (m *Content) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error) {
 	return validate.NewErrors(), nil
 }
+
+// This is a little risky as the tags might not be loaded on the object and there isn't
+// a great way to tell 'loaded' vs just doesn't have tags
+func (m *Content) HasTag(tag string) bool {
+	tags := m.Tags
+	if tags == nil || len(tags) == 0 {
+		return false
+	}
+	for _, t := range tags {
+		if t.ID == tag {
+			return true
+		}
+	}
+	return false
+}

--- a/test_common/helpers.go
+++ b/test_common/helpers.go
@@ -140,6 +140,17 @@ func InitFakeApp(use_db bool) *utils.DirConfigEntry {
 	return cfg
 }
 
+// For loading up the memory app but not searching directories checking content etc.
+func InitMemoryFakeAppEmpty() *utils.DirConfigEntry {
+	dir, _ := envy.MustGet("DIR")
+	fmt.Printf("Using directory %s\n", dir)
+	cfg := ResetConfig()
+	cfg.UseDatabase = false
+	cfg.StaticResourcePath = "./public/build"
+	utils.InitializeEmptyMemory()
+	return cfg
+}
+
 func CreateContentByDirName(test_dir_name string) (*models.Container, models.Contents, error) {
 	cnt, content := GetContentByDirName(test_dir_name)
 

--- a/test_common/helpers.go
+++ b/test_common/helpers.go
@@ -202,7 +202,9 @@ func CreateContainerPath(c *models.Container) (string, error) {
 	cfg := utils.GetCfg()
 	fqPath := ""
 	if cfg.Dir != "" && cfg.Dir != "~" {
-		fqPath = c.GetFqPath()
+		c.Path = cfg.Dir
+		fqPath = c.GetFqPath() // Currently just ignore any path specified in the Container
+		// fmt.Printf("It should be trying to create %s\n", fqPath)
 		if _, err := os.Stat(fqPath); os.IsNotExist(err) {
 			return fqPath, os.Mkdir(fqPath, 0644)
 		}

--- a/utils/mem_storage.go
+++ b/utils/mem_storage.go
@@ -34,7 +34,15 @@ func InitializeMemory(dir_root string) *MemoryStorage {
 	memStorage.ValidContent = files
 	memStorage.ValidScreens = screens
 	memStorage.ValidTags = tags
+	return &memStorage
+}
 
+func InitializeEmptyMemory() *MemoryStorage {
+	memStorage.Initialized = true
+	memStorage.ValidContainers = models.ContainerMap{}
+	memStorage.ValidContent = models.ContentMap{}
+	memStorage.ValidScreens = models.ScreenMap{}
+	memStorage.ValidTags = models.TagsMap{}
 	return &memStorage
 }
 

--- a/utils/mem_storage.go
+++ b/utils/mem_storage.go
@@ -88,7 +88,8 @@ func PopulateMemoryView(dir_root string) (models.ContainerMap, models.ContentMap
 		c.Idx = idx
 		containers[c.ID] = c
 	}
-	log.Printf("LOADING TAGS %s", cfg.TagFile)
+
+	// log.Printf("LOADING TAGS %s", cfg.TagFile)
 	// Only will work if TAG_FILE is actually set to something
 	tags, tErr := ReadTagsFromFile(cfg.TagFile)
 	tagsMap := models.TagsMap{}


### PR DESCRIPTION
* Enables the memory manager editing now that the managers have feature parity
* Makes it so you can search for tags
* Cleans up some unit tests