### PR TITLE
#329 - Give tags a category as well.

### DIFF
--- a/actions/tags.go
+++ b/actions/tags.go
@@ -25,19 +25,25 @@ type TagsResource struct {
 	buffalo.Resource
 }
 
+type TagResponse struct {
+	Total   int         `json:"total"`
+	Results models.Tags `json:"results"`
+}
+
 // List gets all Tags. This function is mapped to the path
 // GET /tags
 func (v TagsResource) List(c buffalo.Context) error {
 	// Get the DB connection from the context
-	var previewTags *models.Tags
-	var err error
-
 	man := managers.GetManager(&c)
-	previewTags, err = man.ListAllTagsContext()
+	previewTags, total, err := man.ListAllTagsContext()
 	if err != nil {
 		return c.Error(http.StatusBadRequest, err)
 	}
-	return c.Render(200, r.JSON(previewTags))
+	tr := TagResponse{
+		Total:   total,
+		Results: *previewTags,
+	}
+	return c.Render(200, r.JSON(tr))
 }
 
 // Show gets the data for one Tag. This function is mapped to

--- a/actions/tags_test.go
+++ b/actions/tags_test.go
@@ -20,9 +20,9 @@ func (as *ActionSuite) Test_TagsResource_List_DB() {
 	res := as.JSON("/tags/").Get()
 	as.Equal(http.StatusOK, res.Code, fmt.Sprintf("Failed to load tags %s", res.Body.String()))
 
-	tags := models.Tags{}
+	tags := TagResponse{}
 	json.NewDecoder(res.Body).Decode(&tags)
-	as.Equal(len(tags), 2, fmt.Sprintf("There should be two tags %s", tags))
+	as.Equal(len(tags.Results), 2, fmt.Sprintf("There should be two tags %s", tags.Results))
 }
 
 func (as *ActionSuite) Test_TagsResource_Show_DB() {
@@ -51,9 +51,9 @@ func (as *ActionSuite) Test_TagsResource_Create_DB() {
 	check := as.JSON("/tags").Get()
 	as.Equal(http.StatusOK, check.Code, fmt.Sprintf("It should find the tag %s", res.Body.String()))
 
-	checkTags := models.Tags{}
+	checkTags := TagResponse{}
 	json.NewDecoder(check.Body).Decode(&checkTags)
-	as.Equal(1, len(checkTags), fmt.Sprintf("We should have a tag %s", check.Body.String()))
+	as.Equal(1, len(checkTags.Results), fmt.Sprintf("We should have a tag %s", check.Body.String()))
 }
 
 func (as *ActionSuite) Test_TagsResource_Update_DB() {

--- a/managers/helper_test.go
+++ b/managers/helper_test.go
@@ -165,14 +165,15 @@ func (as *ActionSuite) Test_CreateBaseTags() {
 	as.NotNil(tags)
 	as.Equal(len(*tags), test_common.TOTAL_TAGS, "It should keep track of what was created")
 
-	tagsCheck, lErr := man.ListAllTags(0, 9000)
+	tagsCheck, total, lErr := man.ListAllTags(TagQuery{PerPage: 50})
 	as.NoError(lErr, "It should not error out listing tags")
+	as.Greater(total, 0, "We should have a tag count")
 	as.NotNil(tags, "There should be tags")
-	as.Equal(len(*tagsCheck), test_common.TOTAL_TAGS, "There should be 4 tags now")
+	as.Equal(test_common.TOTAL_TAGS, len(*tagsCheck), "The tags should be created and queried")
 
 	tagsAgain, retryError := CreateTagsFromFile(man)
 	as.NoError(retryError, "We should not have any DB error")
-	as.Equal(len(*tagsAgain), test_common.TOTAL_TAGS, "There should still be 4 tags")
+	as.Equal(test_common.TOTAL_TAGS, len(*tagsAgain), "The Tag count should be the same.")
 	// Add test to ensure we do not try and create the same tag over and over
 	// TODO: Need to do a test that actually checks memory
 }

--- a/managers/manager.go
+++ b/managers/manager.go
@@ -75,6 +75,14 @@ type ContentQuery struct {
 	Direction     string   `json:"direction" default:"desc"`
 }
 
+type TagQuery struct {
+	Search  string `json:"search" default:""`
+	Text    string `json:"text" default:""`
+	Page    int    `json:"page" default:"1"`
+	PerPage int    `json:"per_page" default:"1000"` // Doesn't work on create?
+	TagType string `json:"tag_type" default:""`
+}
+
 type QueryInterface struct {
 }
 
@@ -126,8 +134,8 @@ type ContentManager interface {
 
 	// Tags listing (oy do I need to deal with this?)
 	GetTag(id string) (*models.Tag, error)
-	ListAllTags(page int, perPage int) (*models.Tags, error)
-	ListAllTagsContext() (*models.Tags, error)
+	ListAllTags(tq TagQuery) (*models.Tags, int, error)
+	ListAllTagsContext() (*models.Tags, int, error)
 	CreateTag(tag *models.Tag) error
 	UpdateTag(tag *models.Tag) error
 	DestroyTag(id string) (*models.Tag, error)

--- a/managers/manager_db_test.go
+++ b/managers/manager_db_test.go
@@ -142,8 +142,9 @@ func (as *ActionSuite) Test_ManagerTagsDB() {
 
 	as.NoError(man.CreateTag(&models.Tag{ID: "A"}), "couldn't create tag A")
 	as.NoError(man.CreateTag(&models.Tag{ID: "B"}), "couldn't create tag B")
-	tags, err := man.ListAllTags(0, 3)
+	tags, total, err := man.ListAllTags(TagQuery{PerPage: 3})
 	as.NoError(err, "It should be able to list tags")
+	as.Greater(total, 0, "It should have a total")
 	as.Equal(len(*tags), 2, "We should have two tags")
 }
 
@@ -154,12 +155,15 @@ func (as *ActionSuite) Test_ManagerTagsDB_CRUD() {
 	t := models.Tag{ID: "A"}
 	as.NoError(man.CreateTag(&t), "couldn't create tag A")
 
-	tags, err := man.ListAllTags(0, 3)
+	tags, total, err := man.ListAllTags(TagQuery{PerPage: 3})
 	as.NoError(err)
+	as.Greater(total, 0, "A tag should exist")
 	as.Equal(len(*tags), 1, "We should have one tag")
 	man.DestroyTag(t.ID)
-	tags_gone, _ := man.ListAllTags(0, 3)
+	tags_gone, total_gone, err := man.ListAllTags(TagQuery{PerPage: 3})
+	as.NoError(err)
 	as.Equal(len(*tags_gone), 0, "No tags should be in the DB")
+	as.Equal(total_gone, 0, "It should have no tags")
 }
 
 func (as *ActionSuite) Test_DbManager_AssociateTags() {
@@ -181,9 +185,10 @@ func (as *ActionSuite) Test_DbManager_AssociateTags() {
 	mc.Screens = models.Screens{s}
 	man.UpdateContent(&mc)
 
-	tags, t_err := man.ListAllTags(0, 10)
+	tags, total, t_err := man.ListAllTags(TagQuery{PerPage: 10})
 	as.NoError(t_err, "We should be able to list tags.")
 	as.Equal(2, len(*tags), fmt.Sprintf("There should be two tags %s", mc))
+	as.Greater(total, 0, "It should have a total")
 
 	screens, count, s_err := man.ListScreens(ScreensQuery{ContentID: mc.ID.String()})
 	as.NoError(s_err, "Screens should list")

--- a/managers/manager_memory_test.go
+++ b/managers/manager_memory_test.go
@@ -281,9 +281,10 @@ func (as *ActionSuite) Test_ManagerTagsMemory() {
 	man := GetManagerActionSuite(cfg, as)
 	as.NoError(man.CreateTag(&models.Tag{ID: "A"}), "couldn't create tag A")
 	as.NoError(man.CreateTag(&models.Tag{ID: "B"}), "couldn't create tag B")
-	tags, err := man.ListAllTags(0, 3)
+	tags, total, err := man.ListAllTags(TagQuery{PerPage: 3})
 	as.NoError(err, "It should be able to list tags")
 	as.Equal(len(*tags), 2, "We should have two tags")
+	as.Equal(total, 2, "It should have a tag count")
 }
 
 // A Lot more of these could be a test in manager that passes in the manager
@@ -302,12 +303,14 @@ func (as *ActionSuite) Test_MangerTagsMemoryCRUD() {
 	as.NoError(man.CreateTag(&t), "couldn't create tag A")
 	as.NoError(man.UpdateTag(&t), "It should udpate")
 
-	tags, err := man.ListAllTags(0, 3)
+	tags, total, err := man.ListAllTags(TagQuery{PerPage: 3})
 	as.NoError(err)
+	as.Equal(total, 1, "there should be one tag")
 	as.Equal(len(*tags), 1, "We should have one tag")
 	man.DestroyTag(t.ID)
-	tags_gone, _ := man.ListAllTags(0, 3)
+	tags_gone, total_gone, _ := man.ListAllTags(TagQuery{PerPage: 3})
 	as.Equal(len(*tags_gone), 0, "Now there should be no tags")
+	as.Equal(total_gone, 0, "it should be empty")
 }
 
 func (as *ActionSuite) Test_ManagerMemoryScreens() {

--- a/migrations/20220908200410_create_tags.up.fizz
+++ b/migrations/20220908200410_create_tags.up.fizz
@@ -1,6 +1,7 @@
 create_table("tags") {
 	t.Column("id", "string", {primary: true})
 	t.Column("description", "string", {default: ""})
+	t.Column("tag_type", "string", {default: ""})
 	t.Timestamps()
 }
 

--- a/mocks/content/dir2/tags.txt
+++ b/mocks/content/dir2/tags.txt
@@ -43,15 +43,15 @@ S3
 SQS
 jquery
 //TagType:typeKeywords
-Google Earth
-Google Maps
-Open Search
+Google_Earth
+Google_Maps
+Open_Search
 Postgis
 Route53
 Angular.io
 
 Angular
 //TagType:actors
-John Travolta
-Keanu Reeves
+John_Travolta
+Keanu_Reeves
 

--- a/mocks/content/dir2/tags.txt
+++ b/mocks/content/dir2/tags.txt
@@ -43,9 +43,9 @@ S3
 SQS
 jquery
 //TagType:typeKeywords
-Google_Earth
-Google_Maps
-Open_Search
+Google Earth
+Google Maps
+Open Search
 Postgis
 Route53
 Angular.io

--- a/mocks/content/dir2/tags.txt
+++ b/mocks/content/dir2/tags.txt
@@ -1,3 +1,7 @@
+// This is a comment, if you have exactly the following line it will associate a tag_type with the following
+// tags.  This can then let you filter your tags by groups.  For syntax highlights you can use some of the known
+// VSCode elements (keywords, typeKeywords, operators)
+//TagType:keywords
 c#
 python
 typescript
@@ -38,9 +42,16 @@ RDS
 S3
 SQS
 jquery
+//TagType:typeKeywords
 Google Earth
 Google Maps
-postgis
+Open Search
+Postgis
 Route53
-OpenSearch
+Angular.io
+
 Angular
+//TagType:actors
+John Travolta
+Keanu Reeves
+

--- a/models/tag.go
+++ b/models/tag.go
@@ -12,6 +12,7 @@ import (
 type Tag struct {
 	ID          string    `json:"id" db:"id"`
 	Description string    `json:"description" db:"description"`
+	TagType     string    `json:"tag_type" db:"tag_type" default:"keyword"`
 	CreatedAt   time.Time `json:"created_at" db:"created_at"`
 	UpdatedAt   time.Time `json:"updated_at" db:"updated_at"`
 	Contents    Contents  `json:"contents,omitempty" many_to_many:"contents_tags"`
@@ -21,6 +22,45 @@ type Tag struct {
 func (t Tag) String() string {
 	jt, _ := json.Marshal(t)
 	return string(jt)
+}
+
+type TagsJsonSort func(i, j int) bool
+
+var VALID_TAG_ORDERS = []string{"created_at", "updated_at", "id", "description", "tag_type"}
+
+func GetTagSort(arr Tags, jsonFieldName string) TagsJsonSort {
+	var theSort TagsJsonSort
+	switch jsonFieldName {
+	case "updated":
+		theSort = func(i, j int) bool {
+			return arr[i].UpdatedAt.Unix() < arr[j].UpdatedAt.Unix()
+		}
+	case "id":
+		theSort = func(i, j int) bool {
+			return arr[i].ID < arr[j].ID
+		}
+	case "tag_type":
+		theSort = func(i, j int) bool {
+			return arr[i].TagType < arr[j].TagType
+		}
+	case "description":
+		theSort = func(i, j int) bool {
+			return arr[i].Description < arr[j].Description
+		}
+	case "created_at":
+		theSort = func(i, j int) bool {
+			return arr[i].CreatedAt.Unix() < arr[j].CreatedAt.Unix()
+		}
+	default:
+		theSort = func(i, j int) bool {
+			return arr[i].ID < arr[j].ID
+		}
+	}
+	return theSort
+}
+
+func GetTagsOrder(order string, direction string) string {
+	return GetValidOrder(VALID_TAG_ORDERS, order, direction, "id")
 }
 
 // Tags is not required by pop and may be deleted

--- a/src/contented/container.cmp.ts
+++ b/src/contented/container.cmp.ts
@@ -71,7 +71,9 @@ export class ContainerCmp implements OnInit, OnDestroy {
     }
 
     public ngOnDestroy() {
-        this.sub.unsubscribe();
+        if (this.sub) {
+            this.sub.unsubscribe();
+        }
     }
 
     public saveContent() {

--- a/src/contented/container.spec.ts
+++ b/src/contented/container.spec.ts
@@ -34,8 +34,6 @@ describe('TestingContainer', () => {
         let interval = dir.getIntervalAround(contents[testIdx], 5, 1);
         expect(interval.length).toBe(5, "We should get a 3 item interval");
 
-        console.log("Wat", interval);
-
         let targetIdx = dir.indexOf(contents[testIdx - 1], interval);
         expect(targetIdx).toBe(0, "It should be in the first result (the previous item)");
 

--- a/src/contented/content.ts
+++ b/src/contented/content.ts
@@ -5,9 +5,14 @@ import {Screen} from './screen';
 // Why does a TAG have an id?!?!  Because goBuffalo really likes the id field.
 export class Tag {
     public id: string;
+    public tag_type: string;
 
-    constructor(tagName: string) {
-        this.id = tagName;
+    constructor(obj: any) {
+        if (typeof obj == 'string') {
+            this.id = obj;
+        } else {
+            Object.assign(this, obj);
+        }
     }
 }
 
@@ -32,8 +37,10 @@ export class Content {
     public meta: string;
 
     public fullText: string|undefined = undefined;
-
     public videoInfo?: VideoCodecInfo;
+
+    public created_at: Date;
+    public updated_at: Date;
 
     constructor(obj: any = {}) {
         this.fromJson(obj);
@@ -44,6 +51,9 @@ export class Content {
             Object.assign(this, raw);
             this.links();
             this.screens = _.map(raw.screens, s => new Screen(s));
+
+            this.created_at = new Date(this.created_at);
+            this.updated_at = new Date(this.updated_at);
         }
     }
 

--- a/src/contented/content.ts
+++ b/src/contented/content.ts
@@ -8,11 +8,20 @@ export class Tag {
     public tag_type: string;
 
     constructor(obj: any) {
+        console.log("Object", obj);
         if (typeof obj == 'string') {
             this.id = obj;
         } else {
             Object.assign(this, obj);
         }
+    }
+
+    isProblem() {
+        let arr = this.id ? this.id.split(" ") : [this.id];
+        if (arr.length > 1) {
+           return true; 
+        }
+        return false;
     }
 }
 

--- a/src/contented/content.ts
+++ b/src/contented/content.ts
@@ -8,7 +8,6 @@ export class Tag {
     public tag_type: string;
 
     constructor(obj: any) {
-        console.log("Object", obj);
         if (typeof obj == 'string') {
             this.id = obj;
         } else {

--- a/src/contented/content_browser.spec.ts
+++ b/src/contented/content_browser.spec.ts
@@ -275,6 +275,8 @@ describe('TestingContentBrowserCmp', () => {
         fixture.detectChanges();
         expect($(".preview-type").length).withContext("There should be a text editor").toEqual(1);
         fixture.detectChanges();
+    
+        httpMock.expectOne(r => r.url.includes(ApiDef.contented.tags)).flush(MockData.tags());
         expect($("vscode-editor-cmp").length).withContext("Text should load the editor").toEqual(1);
         tick(10000);
     }));

--- a/src/contented/contented_nav.cmp.ts
+++ b/src/contented/contented_nav.cmp.ts
@@ -96,7 +96,7 @@ export class ContentedNavCmp implements OnInit {
         let btn = $(`#BTN_${evt.key}`)
         let pos = btn.offset();
         if (pos) {
-            console.log("Position and btn value", pos, btn.val());
+            // console.log("Position and btn value", pos, btn.val());
             let x = pos.left + 32;
             let y = pos.top + 20;
             let rippleRef = this.ripple.launch(x, y, {
@@ -110,7 +110,7 @@ export class ContentedNavCmp implements OnInit {
     }
 
     public handleKey(key: string) {
-        console.log("Handle keypress", key);
+        // console.log("Handle keypress", key);
         switch (key) {
             case 'w':
                 GlobalNavEvents.prevContainer();

--- a/src/contented/contented_service.ts
+++ b/src/contented/contented_service.ts
@@ -1,10 +1,11 @@
 import {Injectable} from '@angular/core';
 import {HttpClient, HttpHeaders, HttpParams, HttpErrorResponse} from '@angular/common/http';
 import {Container, LoadStates} from './container';
-import {Content} from './content';
+import {Content, Tag} from './content';
 import {Screen} from './screen';
 import {TaskRequest} from './task_request';
 import {ApiDef} from './api_def';
+import {TAGS_RESPONSE} from './tagging_syntax';
 
 // The manner in which RxJS does this is really stupid, saving 50K for hours of dev time is fail
 import {Observable, forkJoin, from as observableFrom} from 'rxjs';
@@ -274,6 +275,27 @@ export class ContentedService {
         return this.http.post(url, {}).pipe(
             map(res => {
                 return new TaskRequest(res);
+            })
+        );
+    }
+
+
+    getTags(page: number = 1, perPage: number = 1000, pageType: string = "") {
+        if (TAGS_RESPONSE.initialized) {
+            return observableFrom(new Promise((resolve, reject) => {
+                resolve(TAGS_RESPONSE)
+            }));
+        }
+        let params = new HttpParams();
+        params = params.set("page", "" + page);
+        params = params.set("per_page", "" + perPage);
+        params = params.set("page_type", pageType);
+        return this.http.get(ApiDef.contented.tags, {params: params}).pipe(
+            map((res: any) => {
+                return {
+                    total: res.total || 0,
+                    results: _.map(res.results, t => new Tag(t))
+                };
             })
         );
     }

--- a/src/contented/editor_content.spec.ts
+++ b/src/contented/editor_content.spec.ts
@@ -70,6 +70,7 @@ describe('EditorContentCmp', () => {
 
     let taskUrl = `${ApiDef.tasks.list}?page=1&per_page=25&content_id=${id}`;
     httpMock.expectOne(taskUrl).flush(MockData.taskRequests());
+    httpMock.expectOne(r => r.url.includes(ApiDef.contented.tags)).flush(MockData.tags());
     expect($(".screens-form").length).withContext("Video should have the ability to take screens").toEqual(1);
     tick(15000);
     tick(15000);
@@ -99,6 +100,7 @@ describe('EditorContentCmp', () => {
 
     let taskUrl = `${ApiDef.tasks.list}?page=1&per_page=25&content_id=${content.id}`;
     httpMock.expectOne(taskUrl).flush(MockData.taskRequests());
+    httpMock.expectOne(r => r.url.includes(ApiDef.contented.tags)).flush(MockData.tags());
     tick(15000);
   }));
 });

--- a/src/contented/tagging_syntax.ts
+++ b/src/contented/tagging_syntax.ts
@@ -182,7 +182,10 @@ export class TagLang {
     $.ajax(ApiDef.contented.tags, {
       success: res => {
         // I should also change the color of the type and the keyword.
-        let tags = _.map(res, r => new Tag(r));
+
+        let results = res.results;
+
+        let tags = _.map(results, r => new Tag(r));
         let keywordTags = _.map(_.filter(tags, {tag_type: 'keywords'}), 'id');
         let keywords = keywordTags.concat(
           _.map(languages, lang => _.upperFirst(lang)),

--- a/src/contented/tagging_syntax.ts
+++ b/src/contented/tagging_syntax.ts
@@ -145,10 +145,7 @@ export class TagLang {
       }
     });
     if (!_.isEmpty(hackery)) {
-      let wat = hackery.join("|")
-      let re = new RegExp(wat);
-      console.log("HACKERY", hackery, wat, re);
-      return re;
+      return new RegExp(hackery.join("|"));
     }
     return undefined
   }
@@ -170,15 +167,16 @@ export class TagLang {
       wordPattern: /(-?\d*\.\d\w*)|([^\`\~\!\#\%\^\&\*\(\)\-\=\+\{\}\\\|\;\:\'\"\,\.\<\>\/\?\s]+)/g,
     });
 
+    // These allow for matching specific keys that are multi-word or a pain to match.
     let keywordsHack = this.createHackeryMatcher(keywords);
     let typesHack = this.createHackeryMatcher(typeKeywords);
     let operatorsHack = this.createHackeryMatcher(operators);
     if (keywordsHack) {
-      console.log("Keywords in the hack", keywordsHack)
+      // console.log("Keywords in the hack", keywordsHack)
       syntax.tokenizer.root.push([keywordsHack, 'keyword']);
     }
     if (typesHack) {
-      console.log("Types hack", typesHack)
+      // console.log("Types hack", typesHack)
       syntax.tokenizer.root.unshift([typesHack, 'type']);
     }
     if (!_.isEmpty(operatorsHack)) {

--- a/src/contented/tagging_syntax.ts
+++ b/src/contented/tagging_syntax.ts
@@ -45,13 +45,22 @@ export let TAGGING_SYNTAX = {
       [mailFormat, 'type.identifier'],
       [/^[A-Z].*\./, 'type.identifier'], 
 
-      // MultiWord tags would need to have a different matcher (and remove the hack)
-      [/C#|[a-zA-Z_$][\w$]*/, { 
+
+      // Matching wordlike bounds but this absorbs tokens and then the typeKeywords do not work
+      [/[a-zA-Z_][\w$]*/, { 
         cases: {
          '@typeKeywords': 'keyword',
          '@keywords': 'keyword',
           } 
-       }],
+      }],
+
+      // MultiWord tags would need to have a different matcher (and remove the hack)
+      [/\w+\s\w+/, { 
+        cases: {
+         '@typeKeywords': 'typeKeyword',
+         //'@keywords': 'keyword',
+          } 
+      }],
 
       // whitespace
       { include: '@whitespace' },

--- a/src/contented/video_preview.cmp.ts
+++ b/src/contented/video_preview.cmp.ts
@@ -49,7 +49,7 @@ export class VideoPreviewCmp implements OnInit {
 
 
     public screensLoaded(screens: Array<Screen>) {
-        console.log("Screens loaded", screens);
+        //console.log("Screens loaded", screens);
         if (this.content) {
             this.content.screens = this.content.screens || [];
             _.each(screens, screen => {

--- a/src/contented/vscode_editor.cmp.ts
+++ b/src/contented/vscode_editor.cmp.ts
@@ -156,6 +156,7 @@ export class VSCodeEditorCmp implements OnInit {
       code = str.charCodeAt(j);
       if (!(code > 47 && code < 58) && // numeric (0-9)
           !(code > 64 && code < 91) && // upper alpha (A-Z)
+          !(code === 95) && // upper alpha (A-Z)
           !(code > 96 && code < 123)) { // lower alpha (a-z)
             break;
       }

--- a/src/contented/vscode_editor.cmp.ts
+++ b/src/contented/vscode_editor.cmp.ts
@@ -148,7 +148,7 @@ export class VSCodeEditorCmp implements OnInit {
       _.each(tokenArr, (tokens, lineIdx) => {
         let line = m.getLineContent(lineIdx + 1)
         _.each(tokens, token => {
-          console.log("token.type", token.type)
+          //console.log("token.type", token.type)
           if (token.type == match) {
             // This should work, but doesn't because of crazy word boundry monaco stuff?
             // let position = m.getPositionAt(token.offset + 1);
@@ -158,10 +158,8 @@ export class VSCodeEditorCmp implements OnInit {
             // The highlights work but the word positions are all jacked up
             let word = this.readToken(line, token.offset)
             if (this.tagLookup[word]) {
-              console.log("What the shit", word, line);
               tags.add(word);
             } else {
-              console.log("Problem tags?", line, tags)
               this.processProblemTags(line, tags);
             }
           }
@@ -172,7 +170,7 @@ export class VSCodeEditorCmp implements OnInit {
   }
 
   processProblemTags(line: string, tags: Set<string>) {
-    console.log("Problem line", line);
+    // console.log("Problem line", line);
     _.each(this.problemTags, t => {
       if (line.includes(t.id)) {
         tags.add(t.id)

--- a/src/contented/vscode_editor.spec.ts
+++ b/src/contented/vscode_editor.spec.ts
@@ -15,7 +15,7 @@ let editorValue = ` class Funky() {
   public answer: number = 42;
    constructor (zug: number) {
    }
-   monkey() {
+   monkey() { . Wagggh
    }
 
    Google Earth
@@ -67,7 +67,7 @@ describe('VSCodeEditorCmp', () => {
   });
 
   // TODO: The ajax load of tags is still not working right.
-  fit("Should be able to render the monaco editor and process tokens", waitForAsync(() => {
+  it("Should be able to render the monaco editor and process tokens", waitForAsync(() => {
     cmp.language = "test";
     cmp.editorValue = editorValue;
     fixture.detectChanges()
@@ -77,6 +77,7 @@ describe('VSCodeEditorCmp', () => {
         {id: "number", tag_type: "keywords"},
         {id: "class", tag_type: "keywords"},
         {id: "Google Earth", tag_type: "typeKeywords"},
+        {id: "Wagggh", tag_type: "typeKeywords"},
     ]
     let tags = {
       total: 4,
@@ -89,17 +90,21 @@ describe('VSCodeEditorCmp', () => {
 
     fixture.whenStable().then(() => {
       expect((window as any).monaco).toBeDefined()
-      let ids = _.map(keywords, 'id')
-      tagLang.setMonacoLanguage(cmp.language, ids.slice(0, 3), ["Google Earth", "WTF Mate"]);
+      let ids = _.map(keywords, 'id').slice(0, keywords.length - 2)
+      let types = _.map(keywords, 'id').slice(keywords.length - 2, keywords.length)
+      tagLang.setMonacoLanguage(cmp.language, ids, types);
 
       expect(cmp.descriptionControl.value).toEqual(editorValue);
       let tokens = cmp.getTokens();
-      let tokenType = cmp.getTokens("type");
-      console.log("tokenType", tokenType);
+
 
       expect(cmp.editor).withContext("It should have initialized").toBeDefined();
       expect(tokens.sort()).toEqual(ids.sort())
       expect(cmp.monacoEditor).toBeDefined();
+
+      // Qoutes in the string can still be a problem
+      let tokenTypes = cmp.getTokens("type");
+      expect(tokenTypes.sort()).toEqual(types);
     })
   }));
 });

--- a/src/contented/vscode_editor.spec.ts
+++ b/src/contented/vscode_editor.spec.ts
@@ -6,7 +6,7 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MockData} from '../test/mock/mock_data';
 import {MonacoLoaded, WaitForMonacoLoad, ContentedModule} from './contented_module';
-import {setMonacoLanguage} from './tagging_syntax';
+import {TagLang} from './tagging_syntax';
 import {ApiDef} from './api_def';
 import { VSCodeEditorCmp } from './vscode_editor.cmp';
 
@@ -26,6 +26,7 @@ describe('VSCodeEditorCmp', () => {
   let el: HTMLElement;
   let de: DebugElement;
   let httpMock: HttpTestingController;
+  let tagLang: TagLang;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -47,6 +48,8 @@ describe('VSCodeEditorCmp', () => {
     el = de.nativeElement;
     cmp = fixture.componentInstance;
     httpMock = TestBed.inject(HttpTestingController);
+
+    tagLang = new TagLang();
   });
 
   afterEach(() => {
@@ -69,7 +72,7 @@ describe('VSCodeEditorCmp', () => {
     fixture.whenStable().then(() => {
       expect((window as any).monaco).toBeDefined()
       let keywords = ["constructor", "number", "class"];
-      setMonacoLanguage(cmp.language, keywords, []);
+      tagLang.setMonacoLanguage(cmp.language, keywords, []);
 
       expect(cmp.descriptionControl.value).toEqual(editorValue);
       let tokens = cmp.getTokens();

--- a/src/test/mock/tags.json
+++ b/src/test/mock/tags.json
@@ -1,278 +1,348 @@
-[
-  {
-    "id": "c#",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.134414Z",
-    "updated_at": "2023-10-03T11:38:24.134414Z"
-  },
-  {
-    "id": "python",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.137347Z",
-    "updated_at": "2023-10-03T11:38:24.137347Z"
-  },
-  {
-    "id": "typescript",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.138679Z",
-    "updated_at": "2023-10-03T11:38:24.138679Z"
-  },
-  {
-    "id": "javascript",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.139997Z",
-    "updated_at": "2023-10-03T11:38:24.139997Z"
-  },
-  {
-    "id": "JavaScript",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.141231Z",
-    "updated_at": "2023-10-03T11:38:24.141231Z"
-  },
-  {
-    "id": "ruby",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.142429Z",
-    "updated_at": "2023-10-03T11:38:24.142429Z"
-  },
-  {
-    "id": "perl",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.144105Z",
-    "updated_at": "2023-10-03T11:38:24.144105Z"
-  },
-  {
-    "id": "Go",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.145202Z",
-    "updated_at": "2023-10-03T11:38:24.145202Z"
-  },
-  {
-    "id": "GoLang",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.146288Z",
-    "updated_at": "2023-10-03T11:38:24.146288Z"
-  },
-  {
-    "id": "php",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.147314Z",
-    "updated_at": "2023-10-03T11:38:24.147314Z"
-  },
-  {
-    "id": "java",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.14845Z",
-    "updated_at": "2023-10-03T11:38:24.14845Z"
-  },
-  {
-    "id": "css",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.149498Z",
-    "updated_at": "2023-10-03T11:38:24.149498Z"
-  },
-  {
-    "id": "html",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.150979Z",
-    "updated_at": "2023-10-03T11:38:24.150979Z"
-  },
-  {
-    "id": "azure",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.152697Z",
-    "updated_at": "2023-10-03T11:38:24.152697Z"
-  },
-  {
-    "id": "django",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.154121Z",
-    "updated_at": "2023-10-03T11:38:24.154121Z"
-  },
-  {
-    "id": "gobuffalo",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.155501Z",
-    "updated_at": "2023-10-03T11:38:24.155501Z"
-  },
-  {
-    "id": "GoBuffalo",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.156855Z",
-    "updated_at": "2023-10-03T11:38:24.156855Z"
-  },
-  {
-    "id": "flask",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.158151Z",
-    "updated_at": "2023-10-03T11:38:24.158151Z"
-  },
-  {
-    "id": "bootstrap",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.15961Z",
-    "updated_at": "2023-10-03T11:38:24.15961Z"
-  },
-  {
-    "id": "d3",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.161269Z",
-    "updated_at": "2023-10-03T11:38:24.161269Z"
-  },
-  {
-    "id": "jira",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.163135Z",
-    "updated_at": "2023-10-03T11:38:24.163135Z"
-  },
-  {
-    "id": "aws",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.164627Z",
-    "updated_at": "2023-10-03T11:38:24.164627Z"
-  },
-  {
-    "id": "terraform",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.166097Z",
-    "updated_at": "2023-10-03T11:38:24.166097Z"
-  },
-  {
-    "id": "gitlab",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.167483Z",
-    "updated_at": "2023-10-03T11:38:24.167483Z"
-  },
-  {
-    "id": "ci",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.168912Z",
-    "updated_at": "2023-10-03T11:38:24.168912Z"
-  },
-  {
-    "id": "GitLab",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.170211Z",
-    "updated_at": "2023-10-03T11:38:24.170211Z"
-  },
-  {
-    "id": "ansible",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.171499Z",
-    "updated_at": "2023-10-03T11:38:24.171499Z"
-  },
-  {
-    "id": "postgres",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.172938Z",
-    "updated_at": "2023-10-03T11:38:24.172938Z"
-  },
-  {
-    "id": "mysql",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.174062Z",
-    "updated_at": "2023-10-03T11:38:24.174062Z"
-  },
-  {
-    "id": "MySQL",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.175406Z",
-    "updated_at": "2023-10-03T11:38:24.175406Z"
-  },
-  {
-    "id": "Oracle",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.176771Z",
-    "updated_at": "2023-10-03T11:38:24.176771Z"
-  },
-  {
-    "id": "apache",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.178051Z",
-    "updated_at": "2023-10-03T11:38:24.178051Z"
-  },
-  {
-    "id": "nginx",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.17936Z",
-    "updated_at": "2023-10-03T11:38:24.17936Z"
-  },
-  {
-    "id": "rails",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.180634Z",
-    "updated_at": "2023-10-03T11:38:24.180634Z"
-  },
-  {
-    "id": "iis",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.181995Z",
-    "updated_at": "2023-10-03T11:38:24.181995Z"
-  },
-  {
-    "id": "EC2",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.183363Z",
-    "updated_at": "2023-10-03T11:38:24.183363Z"
-  },
-  {
-    "id": "RDS",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.184691Z",
-    "updated_at": "2023-10-03T11:38:24.184691Z"
-  },
-  {
-    "id": "S3",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.185928Z",
-    "updated_at": "2023-10-03T11:38:24.185928Z"
-  },
-  {
-    "id": "SQS",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.187194Z",
-    "updated_at": "2023-10-03T11:38:24.187194Z"
-  },
-  {
-    "id": "jquery",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.188471Z",
-    "updated_at": "2023-10-03T11:38:24.188471Z"
-  },
-  {
-    "id": "Google Earth",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.190023Z",
-    "updated_at": "2023-10-03T11:38:24.190023Z"
-  },
-  {
-    "id": "Google Maps",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.191206Z",
-    "updated_at": "2023-10-03T11:38:24.191206Z"
-  },
-  {
-    "id": "postgis",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.192384Z",
-    "updated_at": "2023-10-03T11:38:24.192384Z"
-  },
-  {
-    "id": "Route53",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.193544Z",
-    "updated_at": "2023-10-03T11:38:24.193544Z"
-  },
-  {
-    "id": "OpenSearch",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.194962Z",
-    "updated_at": "2023-10-03T11:38:24.194962Z"
-  },
-  {
-    "id": "Angular",
-    "description": "",
-    "created_at": "2023-10-03T11:38:24.196274Z",
-    "updated_at": "2023-10-03T11:38:24.196274Z"
-  }
-]
+{
+  "total": 49,
+  "results": [
+    {
+      "id": "Angular",
+      "description": "",
+      "tag_type": "typeKeywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "Angular.io",
+      "description": "",
+      "tag_type": "typeKeywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "EC2",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "GitLab",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "Go",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "GoBuffalo",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "GoLang",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "Google Earth",
+      "description": "",
+      "tag_type": "typeKeywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "Google Maps",
+      "description": "",
+      "tag_type": "typeKeywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "JavaScript",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "John_Travolta",
+      "description": "",
+      "tag_type": "actors",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "Keanu_Reeves",
+      "description": "",
+      "tag_type": "actors",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "MySQL",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "Open Search",
+      "description": "",
+      "tag_type": "typeKeywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "Oracle",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "Postgis",
+      "description": "",
+      "tag_type": "typeKeywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "RDS",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "Route53",
+      "description": "",
+      "tag_type": "typeKeywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "S3",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "SQS",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "ansible",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "apache",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "aws",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "azure",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "bootstrap",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "c#",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "ci",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "css",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "d3",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "django",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "flask",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "gitlab",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "gobuffalo",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "html",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "iis",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "java",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "javascript",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "jira",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "jquery",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "mysql",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "nginx",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "perl",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "php",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "postgres",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "python",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "rails",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "ruby",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "terraform",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    },
+    {
+      "id": "typescript",
+      "description": "",
+      "tag_type": "keywords",
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z"
+    }
+  ]
+}

--- a/test_common/helpers.go
+++ b/test_common/helpers.go
@@ -23,7 +23,7 @@ import (
 
 const TOTAL_CONTAINERS = 5
 const TOTAL_MEDIA = 32
-const TOTAL_TAGS = 46
+const TOTAL_TAGS = 49
 const VIDEO_FILENAME = "donut_[special( gunk.mp4"
 
 var EXPECT_CNT_COUNT = map[string]int{

--- a/utils/content.go
+++ b/utils/content.go
@@ -340,16 +340,26 @@ func ReadTagsFromFile(tagFile string) (*models.Tags, error) {
 		}
 
 		// I could also make this smarter and do a single IN query and then a single insert
+		tagType := "keywords"
 		sc := bufio.NewScanner(f)
 		for sc.Scan() {
-			tagLine := sc.Text()
+			tagLine := strings.TrimSpace(sc.Text())
+			if tagLine != "" {
+				if strings.Contains(tagLine, "//") {
+					if strings.Contains(tagLine, "//TagType:") {
+						tagTypeArr := strings.Split(tagLine, ":")
+						if len(tagTypeArr) > 1 {
+							tagType = strings.TrimSpace(strings.Join(tagTypeArr[1:], " "))
+						}
+					}
+				} else {
+					name := strings.TrimSpace(tagLine)
+					t := models.Tag{ID: name, TagType: tagType}
+					tags = append(tags, t)
+				}
+			}
 
 			// TODO: Make tags under their sections
-			if tagLine != "" {
-				name := strings.TrimSpace(tagLine)
-				t := models.Tag{ID: name}
-				tags = append(tags, t)
-			}
 		}
 	} else {
 		log.Printf("No tagfile found at %s", tagFile)

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -276,7 +276,7 @@ func Test_TagFileRead(t *testing.T) {
 		if tag.TagType == "typeKeywords" {
 			typeKeywordCount += 1
 		}
-		if tag.TagType == "actor" {
+		if tag.TagType == "actors" {
 			actorCount += 1
 		}
 	}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -246,3 +246,48 @@ func Test_Channels(t *testing.T) {
 		t.Errorf("What the actual fuck %s", b)
 	}
 }
+
+func Test_TagFileRead(t *testing.T) {
+	var testDir, _ = envy.MustGet("DIR")
+	tagFile := filepath.Join(testDir, "dir2", "tags.txt")
+
+	tags, err := ReadTagsFromFile(tagFile)
+	if err != nil {
+		t.Errorf("It should not have an issue reading the tag file %s", err)
+	}
+	if tags == nil {
+		t.Errorf("No tags were found %s", err)
+	}
+	if len(*tags) < 5 {
+		t.Errorf("There were not enough tags found")
+	}
+
+	actorCount := 0
+	actorExpect := 2
+	typeKeywordCount := 0
+	typeKeywordExpect := 7
+	keywordCount := 0
+	keywordExpect := 40
+
+	for _, tag := range *tags {
+		if tag.TagType == "keywords" {
+			keywordCount += 1
+		}
+		if tag.TagType == "typeKeywords" {
+			typeKeywordCount += 1
+		}
+		if tag.TagType == "actor" {
+			actorCount += 1
+		}
+	}
+	if actorExpect != actorCount {
+		t.Errorf("Actor count should be %d but was %d", actorExpect, actorCount)
+	}
+	if typeKeywordExpect != typeKeywordCount {
+		t.Errorf("typeKeywords count should be %d but was %d", typeKeywordExpect, typeKeywordCount)
+	}
+	if keywordExpect != keywordCount {
+		t.Errorf("keywords count should be %d but was %d", keywordExpect, keywordCount)
+	}
+
+}


### PR DESCRIPTION
TagType is now a part of the API
Changes API as well to have the usual pagination, query etc.
Adds in proper matching for spaced keywords (ugly but works)