### PR TITLE
IS-449 - Fixes up the screen creation to both clear the initial creation and assign an ID for the memory version.

### DIFF
--- a/managers/manager.go
+++ b/managers/manager.go
@@ -148,6 +148,7 @@ type ContentManager interface {
 	// Functions that help with viewing movie screens if found.
 	ListScreensContext() (*models.Screens, int64, error)
 	ListScreens(sr ScreensQuery) (*models.Screens, int64, error)
+	ClearScreens(content *models.Content) error
 
 	GetScreen(psID int64) (*models.Screen, error)
 	CreateScreen(s *models.Screen) error

--- a/managers/manager_db.go
+++ b/managers/manager_db.go
@@ -438,6 +438,15 @@ func (cm ContentManagerDB) ListScreens(sr ScreensQuery) (*models.Screens, int64,
 	return previews, count, nil
 }
 
+func (cm ContentManagerDB) ClearScreens(content *models.Content) error {
+	if content == nil || content.ID == 0 {
+		return fmt.Errorf("cannot clear screens without content or a valid id")
+	}
+	tx := cm.GetConnection()
+	removed := tx.Exec("DELETE FROM screens WHERE content_id = ?", content.ID)
+	return removed.Error
+}
+
 // Need to make it use the manager and just show the file itself
 func (cm ContentManagerDB) GetScreen(psID int64) (*models.Screen, error) {
 	previewScreen := &models.Screen{}

--- a/managers/manager_memory.go
+++ b/managers/manager_memory.go
@@ -547,6 +547,27 @@ func (cm ContentManagerMemory) ListScreens(sq ScreensQuery) (*models.Screens, in
 	return &s_arr, int64(count), nil
 }
 
+func (cm ContentManagerMemory) ClearScreens(content *models.Content) error {
+	if content == nil || content.ID == 0 {
+		return fmt.Errorf("cannot clear screens without content or a valid id")
+	}
+	// Update the screens reference
+	content.Screens = models.Screens{}
+
+	screenMap := cm.GetStore().ValidScreens
+	screens := []int64{}
+	for _, screen := range screenMap {
+		if screen.ContentID == content.ID {
+			screens = append(screens, screen.ID)
+		}
+	}
+	// Remove the in memory screens
+	for _, screenID := range screens {
+		delete(screenMap, screenID)
+	}
+	return nil
+}
+
 func (cm ContentManagerMemory) GetScreen(psID int64) (*models.Screen, error) {
 	// Need to build out a memory setup and look the damn thing up :(
 	mem := cm.GetStore()

--- a/managers/manager_memory_test.go
+++ b/managers/manager_memory_test.go
@@ -153,7 +153,7 @@ func TestMemoryManagerSearch(t *testing.T) {
 	sr := ContentQuery{Search: "Donut", PerPage: 20}
 	mcs, total, err := man.SearchContent(sr)
 	assert.NoError(t, err, "Can we search in the memory manager")
-	assert.Equal(t, len(*mcs), 1, "One donut should be found")
+	assert.Equal(t, 1, len(*mcs), "One donut should be found")
 	assert.Equal(t, total, int64(len(*mcs)), "It should get the total right")
 
 	sr = ContentQuery{Search: "Large", PerPage: 6}

--- a/utils/mem_storage.go
+++ b/utils/mem_storage.go
@@ -233,12 +233,18 @@ func PopulateMemoryView(dir_root string) (models.ContainerMap, models.ContentMap
 			for _, mc := range ct.Content {
 				// Assign anything required to the content before we put it in the lookup hash
 				AssignPreviewIfExists(&c, &mc)
+				content := mc
 				if screenErr == nil {
-					screens := AssignScreensFromSet(&c, &mc, maybeScreens)
+
+					// Awkward assignment of screen ID and re-assignment to the content element
+					screens := AssignScreensFromSet(&c, &content, maybeScreens)
 					if screens != nil {
 						for _, screen := range *screens {
-							screensMap[screen.ID] = screen
+							s := screen
+							s.ID = AssignNumerical(screen.ID, "screens")
+							screensMap[s.ID] = s
 						}
+						content.Screens = *screens
 					}
 				} else {
 					log.Printf("No potential screens present in container %s", c.Path)

--- a/utils/previews.go
+++ b/utils/previews.go
@@ -644,13 +644,11 @@ func AssignScreensFromSet(c *models.Container, mc *models.Content, maybeScreens 
 	// ie: 1000 episodes of One Piece * (15 screens  + 1 webp) in a loop running
 	// the regex against them all over and over...
 	previewScreens := models.Screens{}
+
 	for idx, fRef := range *maybeScreens {
 		name := fRef.Name()
 		if screenRe.MatchString(name) {
-			// log.Printf("Matched file %s idx %d", name, idx)
-			id := AssignNumerical(0, "screens")
 			ps := models.Screen{
-				ID:        id,
 				Path:      previewPath,
 				Src:       name,
 				ContentID: mc.ID,


### PR DESCRIPTION
* Makes it so the screens assign an ID (they used to just rely on assigning a UUID)
* Cleans up an error where the DB version would bail inserting the same entries.