### PR TITLE
Adding in remove capabilities on detecting duplicates in the UI

### DIFF
--- a/.env
+++ b/.env
@@ -90,6 +90,9 @@ SPLASH_RENDERER_TYPE="video"  # video|container
 SPLASH_HTML_FILE="/Users/ubermeatshield/code/contented/example.htm"
 SPLASH_TITLE="This will be the title in the first rendering card."
 
+# On remove what should it do with content? If set removed content will be moved here
+REMOVAL_LOCATION=""
+
 # TAG_FILE provide the location of a tag file, one tag per line. Not if this is uncommented it stomps
 # any environment variable in the makefile
 # TAG_FILE=""

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ venv/*
 bin/*
 locales/*
 migrations/schema.sql
-devops/inventory.ini
 tmp/*
 
 .grifter/

--- a/devops/inventory.ini
+++ b/devops/inventory.ini
@@ -1,5 +1,5 @@
 [contented_servers]
-your.server.com ansible_python_interpreter=/usr/bin/python3
+98.80.157.168 ansible_python_interpreter=/usr/bin/python3
 
 [contented_servers:vars]
 ansible_user=ec2-user

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module contented
 
-go 1.19
+go 1.23.0
+
+toolchain go1.24.1
 
 require (
 	github.com/disintegration/imaging v1.6.2

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,7 @@ github.com/gin-gonic/gin v1.10.0 h1:nTuyha1TYqgedzytsKYqna+DfLos46nTv2ygFy86HFU=
 github.com/gin-gonic/gin v1.10.0/go.mod h1:4PMNQiOhvDRa013RKVbsiNwoyezlm2rm0uX/T7kzp5Y=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
+github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
 github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=
@@ -257,6 +258,7 @@ google.golang.org/protobuf v1.34.1 h1:9ddQBjfCyZPOHPUiPxpYESBLc+T8P3E+Vo4IbKZgFW
 google.golang.org/protobuf v1.34.1/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkg/actions/contents.go
+++ b/pkg/actions/contents.go
@@ -144,7 +144,6 @@ func ContentsResourceDestroy(c *gin.Context) {
 		return
 	}
 	// TODO: Manager should ABSOLUTELY be the thing doing updates etc.
-	// Allocate an empty Content
 	id, argErr := strconv.ParseInt(c.Param("content_id"), 10, 64)
 	if argErr != nil {
 		c.AbortWithError(http.StatusBadRequest, argErr)
@@ -160,6 +159,9 @@ func ContentsResourceDestroy(c *gin.Context) {
 			return
 		}
 	}
+
+	// This will only remove content from the disk if the remove location is set in the environment
+	managers.RemoveContentFromDisk(man, content)
 	c.JSON(http.StatusOK, content)
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -115,6 +115,7 @@ type DirConfigEntry struct {
 	// TODO: Handle it being mp4?
 	EncodingFilenameModifier string // After re-encoding filename<EncodingFilenameModifier>.mp4
 	RemoveDuplicateFiles     bool   // Removing old video files after re-encoding
+	RemoveLocation           string // If defined and something we can write to delete of content will move the files here
 
 	StartQueueWorkers bool // Should we process requested tasks on this server
 
@@ -180,6 +181,7 @@ func GetCfgDefaults() DirConfigEntry {
 
 		EncodingFilenameModifier: DefaultEncodingFilenameModifier,
 		RemoveDuplicateFiles:     false,
+		RemoveLocation:           "",
 
 		// Should this server start up processing tasks for tasking screens, encoding etc.
 		StartQueueWorkers: true,
@@ -328,8 +330,7 @@ func InitConfigEnvy(cfg *DirConfigEntry) *DirConfigEntry {
 	// TODO: Make this a little saner on the name side
 	cfg.EncodingFilenameModifier = GetEnvString("ENCODING_FILENAME_MODIFIER", DefaultEncodingFilenameModifier)
 	cfg.RemoveDuplicateFiles = GetEnvBool("REMOVE_DUPLICATE_FILES", false)
-
-	// There must be a cleaner way to do some of this default loading...
+	cfg.RemoveLocation = GetEnvString("REMOVE_LOCATION", "")
 
 	cfg.ExcludeEmptyContainers = GetEnvBool("EXCLUDE_EMPTY_CONTAINER", DefaultExcludeEmptyContainers)
 	cfg.MaxSearchDepth = GetEnvInt("MAX_SEARCH_DEPTH", DefaultMaxSearchDepth)

--- a/pkg/test_common/helpers.go
+++ b/pkg/test_common/helpers.go
@@ -85,6 +85,22 @@ func CreateTestPreviewsContainerDirectory(t *testing.T) (string, string) {
 	return containerPreviews, testDir
 }
 
+func CreateTestContentInContainer(cnt *models.Container, fileName string, writeString string) (*models.Content, error) {
+	testFile := "test.txt"
+	contentPath := filepath.Join(cnt.GetFqPath(), testFile)
+
+	err := os.WriteFile(contentPath, []byte(writeString), 0644)
+	if err != nil {
+		return nil, err
+	}
+	content := models.Content{
+		ID:          42,
+		ContainerID: &cnt.ID,
+		Src:         testFile,
+	}
+	return &content, nil
+}
+
 // duplicated in utils/previews_test.go
 func WriteScreenFile(dstPath string, fileName string, count int) (string, error) {
 	screenName := fmt.Sprintf("%s.screens.00%d.jpg", fileName, count)

--- a/src/contented/admin_search.cmp.ts
+++ b/src/contented/admin_search.cmp.ts
@@ -2,7 +2,8 @@ import { SearchCmp } from './search.cmp';
 import { Component, Input } from '@angular/core';
 import { Content } from './content';
 import { GlobalNavEvents } from './nav_events';
-
+import { GlobalBroadcast } from './global_message';
+import * as _ from 'lodash';
 // TODO: When styling out the search add a hover and hover text to make it
 // more obvious when something can be clicked.
 @Component({
@@ -18,7 +19,19 @@ export class AdminSearchCmp extends SearchCmp {
   }
 
   removeDuplicate(mc: Content) {
-    console.log('Remove duplicate', mc);
-    GlobalNavEvents.removeDuplicate(mc);
+    if (mc.duplicate) {
+      GlobalNavEvents.removeDuplicate(mc);
+      this._contentedService.removeContent(mc.id).subscribe({
+        next: res => {
+          console.log('Removed duplicate', res, mc.id);
+          this.content = _.filter(this.content, content => content.id !== mc.id);
+        },
+        error: err => {
+          GlobalBroadcast.error('Error removing duplicate', err);
+        },
+      });
+    } else {
+      console.log('Not a duplicate', mc);
+    }
   }
 }

--- a/src/contented/contented_service.ts
+++ b/src/contented/contented_service.ts
@@ -129,6 +129,11 @@ export class ContentedService {
     );
   }
 
+  public removeContent(contentID: string) {
+    let url = ApiDef.contented.content.replace('{id}', contentID);
+    return this.http.delete(url, this.options).pipe(catchError(err => this.handleError(err)));
+  }
+
   // Do a preview load (should it be API?)
 
   // TODO: Make all the test mock data new and or recent

--- a/src/contented/search.ng.html
+++ b/src/contented/search.ng.html
@@ -11,7 +11,10 @@
     <ng-template matMenuContent let-content="content">
       <button mat-menu-item (click)="addFavorite(content)">Toggle Favorite</button>
       <button mat-menu-item (click)="toggleDuplicate(content)">Toggle Duplicate</button>
-      <button mat-menu-item *ngIf="showToggleDuplicate" (click)="removeDuplicate(content)">Remove Duplicate</button>
+      <button mat-menu-item 
+        *ngIf="showToggleDuplicate && content?.duplicate" 
+        (click)="removeDuplicate(content)"
+      >Remove Duplicate</button>
     </ng-template>
   </mat-menu>
 


### PR DESCRIPTION
* Dupes will be moved to a removal folder if it is specified in .env (fqpath)
* Dupes can be removed from the admin search